### PR TITLE
Enable using markdown for Sphinx docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,8 +25,10 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 if on_rtd:
     import pip
     pip.main(['install', 'sphinx_bootstrap_theme'])
+    pip.main(['install', 'recommonmark'])
 
 import sphinx_bootstrap_theme
+from recommonmark.parser import CommonMarkParser
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -49,10 +51,14 @@ extensions = [
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
+source_parsers = {
+    '.md': CommonMarkParser,
+}
+
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 # source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = ['.rst', '.md']
 
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'


### PR DESCRIPTION
I'm going to admit it... reStructured Text is _driving me nuts_.

It turns out that there's an RTFD-supported extension that parses Markdown and enables it to be used with Sphinx by injecting the right RST-style metadata where necessary. This would certainly make writing docs easier for me :laughing:

I don't want to force a full translation task here, but I was thinking that if others are interested we could begin writing new pages in Markdown (e.g. #399). Thoughts? I figure this PR is a fine place to discuss, I'm not trying to force it.