### PR TITLE
Add a wait_until_angle_changed_by() method to GyroSensor

### DIFF
--- a/ev3dev/sensor/lego.py
+++ b/ev3dev/sensor/lego.py
@@ -430,6 +430,17 @@ class GyroSensor(Sensor):
         self.mode = self.MODE_GYRO_ANG
         self._direct = self.set_attr_raw(self._direct, 'direct', 17)
 
+    def wait_until_angle_changed_by(self, delta):
+        """
+        Wait until angle has changed by specified amount.
+        """
+        assert self.mode in (self.MODE_GYRO_G_A, self.MODE_GYRO_ANG,
+                             self.MODE_TILT_ANG),\
+            'Gyro mode should be MODE_GYRO_ANG, MODE_GYRO_G_A or MODE_TILT_ANG'
+        start_angle = self.value(0)
+        while abs(start_angle - self.value(0)) < delta:
+            time.sleep(0.01)
+
 
 class InfraredSensor(Sensor, ButtonBase):
     """


### PR DESCRIPTION
This adds a method to the GyroSensor class that simplifies the required code when using the gyro sensor to make accurate turns. Here is a short example:
```
motor_pair = MoveSteering(OUTPUT_B, OUTPUT_C)
gyro = GyroSensor()

# Spin robot to the left
motor_pair.on(steering=-100, speed_pct=5)

# Wait until angle changed by 90 degrees
gyro.wait_until_angle_changed_by(90)

# Stop motors
motor_pair.off()
```
Have discussed this with @dwalton76.