### PR TITLE
Replaces print statement with built in function

### DIFF
--- a/tests/motor/ev3dev_port_logger.py
+++ b/tests/motor/ev3dev_port_logger.py
@@ -86,4 +86,4 @@ for p,v in test['meta']['ports'].items():
      test['data'][p] = logs[p].results
 
 # Add a nice JSON formatter here - maybe?
-print json.dumps( test, indent = 4 )
+print (json.dumps( test, indent = 4 ))

--- a/tests/motor/plot_matplotlib.py
+++ b/tests/motor/plot_matplotlib.py
@@ -67,7 +67,7 @@ for k,d in test['data'].items():
 
     # Clean up the chartjunk
     for i,ax in enumerate(axarr):
-        print(i),(ax)
+        print(i, ax)
         # Remove the plot frame lines. They are unnecessary chartjunk.
         ax.spines["top"].set_visible(False)
 

--- a/tests/motor/plot_matplotlib.py
+++ b/tests/motor/plot_matplotlib.py
@@ -67,7 +67,7 @@ for k,d in test['data'].items():
 
     # Clean up the chartjunk
     for i,ax in enumerate(axarr):
-        print i, ax
+        print(i),(ax)
         # Remove the plot frame lines. They are unnecessary chartjunk.
         ax.spines["top"].set_visible(False)
 


### PR DESCRIPTION
The print statement was removed with Python3, this change should work
for both Python2 and Python3.

The ```print(i),(ax)``` looks a little strange though.

I just ran an out-of-the-box sonar analysis on the project and found this: it wasn't actually causing me any issue.