### PR TITLE
lego.py color sensor documentation fix

### DIFF
--- a/ev3dev/sensor/lego.py
+++ b/ev3dev/sensor/lego.py
@@ -114,7 +114,7 @@ class ColorSensor(Sensor):
     #: Reflected light. Red LED on.
     MODE_COL_REFLECT = 'COL-REFLECT'
 
-    #: Ambient light. Red LEDs off.
+    #: Ambient light. Blue LEDs on.
     MODE_COL_AMBIENT = 'COL-AMBIENT'
 
     #: Color. All LEDs rapidly cycling, appears white.


### PR DESCRIPTION
https://github.com/ev3dev/ev3dev/issues/317
Indeed, ambient mode turns the led to blue.