### PR TITLE
partial brickpi3 support

### DIFF
--- a/ev3dev2/_platform/brickpi3.py
+++ b/ev3dev2/_platform/brickpi3.py
@@ -1,3 +1,13 @@
 
+OUTPUT_A = 'spi0.1:MA'
+OUTPUT_B = 'spi0.1:MB'
+OUTPUT_C = 'spi0.1:MC'
+OUTPUT_D = 'spi0.1:MD'
+
+INPUT_1 = 'spi0.1:S1'
+INPUT_2 = 'spi0.1:S2'
+INPUT_3 = 'spi0.1:S3'
+INPUT_4 = 'spi0.1:S4'
+
 BUTTONS_FILENAME = None
 EVDEV_DEVICE_NAME = None

--- a/ev3dev2/motor.py
+++ b/ev3dev2/motor.py
@@ -1022,6 +1022,9 @@ class MediumMotor(Motor):
 
     def __init__(self, address=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, name_exact=False, **kwargs):
 
+        if platform in ('brickpi', 'brickpi3'):
+            raise Exception("%s is unaware of different motor types, use LargeMotor instead" % platform)
+
         super(MediumMotor, self).__init__(address, name_pattern, name_exact, driver_name=['lego-ev3-m-motor'], **kwargs)
 
 


### PR DESCRIPTION
This only gets us part of the way to really supporting brickpi3 in ev3dev-lang-python. Some driver work needs to be done in the kernel for brickpi3 to be event-driven with the motor state file