### PR TITLE
Update display for 4.14 kernel

### DIFF
--- a/ev3dev2/display.py
+++ b/ev3dev2/display.py
@@ -198,14 +198,12 @@ class Display(FbMem):
 
         self.platform = get_current_platform()
 
-        if self.platform == "ev3" and self.var_info.bits_per_pixel == 1:
-            # Pre 4.14 kernel
+        if self.var_info.bits_per_pixel == 1:
             im_type = "1"
-        elif self.platform == "ev3" and self.var_info.bits_per_pixel == 32:
-            # Post 4.14 kernel
-            im_type = "L"
-        elif self.platform == "pistorms" and self.var_info.bits_per_pixel == 16:
+        elif self.var_info.bits_per_pixel == 16:
             im_type = "RGB"
+        elif self.platform == "ev3" and self.var_info.bits_per_pixel == 32:
+            im_type = "L"
         else:
             raise Exception("Not supported")
 
@@ -295,15 +293,13 @@ class Display(FbMem):
         Applies pending changes to the screen.
         Nothing will be drawn on the screen until this function is called.
         """
-        if self.platform == "ev3" and self.var_info.bits_per_pixel == 1:
-            # Pre 4.14 kernel
+        if self.var_info.bits_per_pixel == 1:
             b = self._img.tobytes("raw", "1;R")
             self.mmap[:len(b)] = b
-        elif self.platform == "ev3" and self.var_info.bits_per_pixel == 32:
-            # Post 4.14 kernel
-            self.mmap[:] = self._img_to_xrgb_bytes()
-        elif self.platform == "pistorms" and self.var_info.bits_per_pixel == 16:
+        elif self.var_info.bits_per_pixel == 16:
             self.mmap[:] = self._img_to_rgb565_bytes()
+        elif self.platform == "ev3" and self.var_info.bits_per_pixel == 32:
+            self.mmap[:] = self._img_to_xrgb_bytes()
         else:
             raise Exception("Not supported")
 

--- a/ev3dev2/display.py
+++ b/ev3dev2/display.py
@@ -33,6 +33,7 @@ import mmap
 import ctypes
 from PIL import Image, ImageDraw
 from . import fonts
+from . import get_current_platform
 from struct import pack
 import fcntl
 
@@ -195,12 +196,16 @@ class Display(FbMem):
     def __init__(self, desc='Display'):
         FbMem.__init__(self)
 
-        if self.var_info.bits_per_pixel == 1:
+        self.platform = get_current_platform()
+
+        if self.platform == "ev3" and self.var_info.bits_per_pixel == 1:
+            # Pre 4.14 kernel
             im_type = "1"
-        elif self.var_info.bits_per_pixel == 16:
-            im_type = "RGB"
-        elif self.var_info.bits_per_pixel == 32:
+        elif self.platform == "ev3" and self.var_info.bits_per_pixel == 32:
+            # Post 4.14 kernel
             im_type = "L"
+        elif self.platform == "pistorms" and self.var_info.bits_per_pixel == 16:
+            im_type = "RGB"
         else:
             raise Exception("Not supported")
 
@@ -290,13 +295,15 @@ class Display(FbMem):
         Applies pending changes to the screen.
         Nothing will be drawn on the screen until this function is called.
         """
-        if self.var_info.bits_per_pixel == 1:
+        if self.platform == "ev3" and self.var_info.bits_per_pixel == 1:
+            # Pre 4.14 kernel
             b = self._img.tobytes("raw", "1;R")
             self.mmap[:len(b)] = b
-        elif self.var_info.bits_per_pixel == 16:
-            self.mmap[:] = self._img_to_rgb565_bytes()
-        elif self.var_info.bits_per_pixel == 32:
+        elif self.platform == "ev3" and self.var_info.bits_per_pixel == 32:
+            # Post 4.14 kernel
             self.mmap[:] = self._img_to_xrgb_bytes()
+        elif self.platform == "pistorms" and self.var_info.bits_per_pixel == 16:
+            self.mmap[:] = self._img_to_rgb565_bytes()
         else:
             raise Exception("Not supported")
 

--- a/ev3dev2/display.py
+++ b/ev3dev2/display.py
@@ -31,8 +31,8 @@ if sys.version_info < (3,4):
 import os
 import mmap
 import ctypes
-import ev3dev.fonts as fonts
 from PIL import Image, ImageDraw
+from . import fonts
 from struct import pack
 import fcntl
 
@@ -195,8 +195,17 @@ class Display(FbMem):
     def __init__(self, desc='Display'):
         FbMem.__init__(self)
 
+        if self.var_info.bits_per_pixel == 1:
+            im_type = "1"
+        elif self.var_info.bits_per_pixel == 16:
+            im_type = "RGB"
+        elif self.var_info.bits_per_pixel == 32:
+            im_type = "L"
+        else:
+            raise Exception("Not supported")
+
         self._img = Image.new(
-                self.var_info.bits_per_pixel == 1 and "1" or "RGB",
+                im_type,
                 (self.fix_info.line_length * 8 // self.var_info.bits_per_pixel, self.yres),
                 "white")
 
@@ -266,6 +275,16 @@ class Display(FbMem):
         pixels = [self._color565(r, g, b) for (r, g, b) in self._img.getdata()]
         return pack('H' * len(pixels), *pixels)
 
+    def _color_xrgb(self, v):
+        """Convert red, green, blue components to a 32-bit XRGB value. Components
+        should be values 0 to 255.
+        """
+        return ((v << 24) | (v << 16) | (v << 8))
+
+    def _img_to_xrgb_bytes(self):
+        pixels = [self._color_xrgb(v) for v in self._img.getdata()]
+        return pack('I' * len(pixels), *pixels)
+
     def update(self):
         """
         Applies pending changes to the screen.
@@ -276,6 +295,8 @@ class Display(FbMem):
             self.mmap[:len(b)] = b
         elif self.var_info.bits_per_pixel == 16:
             self.mmap[:] = self._img_to_rgb565_bytes()
+        elif self.var_info.bits_per_pixel == 32:
+            self.mmap[:] = self._img_to_xrgb_bytes()
         else:
             raise Exception("Not supported")
 

--- a/ev3dev2/display.py
+++ b/ev3dev2/display.py
@@ -282,7 +282,7 @@ class Display(FbMem):
         """Convert red, green, blue components to a 32-bit XRGB value. Components
         should be values 0 to 255.
         """
-        return ((v << 24) | (v << 16) | (v << 8))
+        return ((v << 16) | (v << 8) | v)
 
     def _img_to_xrgb_bytes(self):
         pixels = [self._color_xrgb(v) for v in self._img.getdata()]


### PR DESCRIPTION
Tested on the latest ([2018-04-22](https://oss.jfrog.org/list/oss-snapshot-local/org/ev3dev/brickstrap/2018-04-22)) stretch image. It works, and is indeed able to produce grayscale images:
```py
from time import sleep
from ev3dev2.auto import Display, Sound
from ev3dev2 import fonts

Sound().beep()

d = Display()
d.clear()
d.draw.rectangle((10,10,60,20,), fill='black')
d.draw.rectangle((10,20,60,30,), fill='gray')
d.draw.text((10,40), 'Hello1', font=fonts.load('luBS14'), fill='black')
d.draw.text((10,50), 'Hello2', font=fonts.load('luBS14'), fill='gray')
d.draw.text((10,60), 'Hello3', font=fonts.load('luBS14'))
d.update()
sleep(5)
```
![test](https://user-images.githubusercontent.com/270503/39419171-499d0918-4c67-11e8-83d6-eab79aa1f852.png)

Fixes #455 