### PR TITLE
Fix CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ install:
 - pip install Pillow
 - pip install evdev
 script:
+- chmod -R g+rw ./tests/fake-sys/devices/**/*
 - ./tests/api_tests.py
 deploy:
   provider: pypi

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -86,5 +86,15 @@ class TestAPI(unittest.TestCase):
         self.assertEqual(s.address,         'in1')
         self.assertEqual(s.value(0),        16)
 
+    def test_medium_motor_write(self):
+        clean_arena()
+        populate_arena({'medium_motor' : [0, 'outA']})
+
+        m = MediumMotor()
+
+        self.assertEqual(m.speed_sp, 0)
+        m.speed_sp = 500
+        self.assertEqual(m.speed_sp, 500)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
First commit adds a failing test (we didn't write to properties before); second commit fixes it 💪😎. I don't entirely understand why the files had different permissions on the CI server from what I see when I clone in Ubuntu locally, but whatever the issue is, checking for user permissions seems to work. I'll validate this on an EV3 soon to confirm I didn't cause any regressions.