### PR TITLE
Use Pillow manipulation logic for grey-to-RGB conversion on EV3 to improve perf

### DIFF
--- a/ev3dev2/display.py
+++ b/ev3dev2/display.py
@@ -287,16 +287,6 @@ class Display(FbMem):
         pixels = [self._color565(r, g, b) for (r, g, b) in self._img.getdata()]
         return pack('H' * len(pixels), *pixels)
 
-    def _color_xrgb(self, v):
-        """Convert red, green, blue components to a 32-bit XRGB value. Components
-        should be values 0 to 255.
-        """
-        return ((v << 16) | (v << 8) | v)
-
-    def _img_to_xrgb_bytes(self):
-        pixels = [self._color_xrgb(v) for v in self._img.getdata()]
-        return pack('I' * len(pixels), *pixels)
-
     def update(self):
         """
         Applies pending changes to the screen.
@@ -308,7 +298,7 @@ class Display(FbMem):
         elif self.var_info.bits_per_pixel == 16:
             self.mmap[:] = self._img_to_rgb565_bytes()
         elif self.platform == "ev3" and self.var_info.bits_per_pixel == 32:
-            self.mmap[:] = self._img_to_xrgb_bytes()
+            self.mmap[:] = self._img.convert("RGB").tobytes("raw", "XRGB")
         else:
             raise Exception("Not supported")
 


### PR DESCRIPTION
As reported in https://github.com/ev3dev/ev3dev/issues/1150, our display update code is _really slow_. As in... several seconds for a single display update. I've concluded that the primary issue is that our home-grown conversion from 8bpp greyscale to 32bpp is an unoptimized blob of Python (compared to the pure C implementation in PIL/Pillow). After some investigation and experimenting, I found a couple ways to take advantage of the pre-build Pillow conversions, and included the fastest here.

Performance:
- `v1.0` series (when the display driver accepted 1bpp directly): **27FPS max**
- `v2.0` series now (with our custom converter): **0.2FPS max**
- Code included in this PR: **8FPS max**

So this improves the current code by a factor of 40, but is still three times slower than what we had in v1.

I am tempted to open a PR on Pillow, but judging by A) their largely ignoring external PRs and b) the fact that the file in question hasn't been modified for almost a year, I'm not fond of my chances at getting code in there.

Note that this only updates the EV3; whatever platforms require the "565" scheme are still going to be slow, and I don't see a Pillow built-in for such a format. Perhaps someone could suggest something there.
