### PR TITLE
Improve speed integer and rename "speed_pct" to "speed"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: false
 git:
   depth: 100
 install:
-- pip install q Pillow evdev Sphinx sphinx_bootstrap_theme recommonmark evdev
+- pip install q Pillow Sphinx sphinx_bootstrap_theme recommonmark evdev==1.0.0
 - pip install -r ./docs/requirements.txt
 script:
 - chmod -R g+rw ./tests/fake-sys/devices/**/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: false
 git:
   depth: 100
 install:
-- pip install q Pillow Sphinx sphinx_bootstrap_theme recommonmark evdev==1.0.0
+- pip install Pillow Sphinx sphinx_bootstrap_theme recommonmark evdev==1.0.0
 - pip install -r ./docs/requirements.txt
 script:
 - chmod -R g+rw ./tests/fake-sys/devices/**/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ sudo: false
 git:
   depth: 100
 install:
-- pip install -q Pillow evdev Sphinx sphinx_bootstrap_theme recommonmark evdev
-- pip install -q -r ./docs/requirements.txt
+- pip install q Pillow evdev Sphinx sphinx_bootstrap_theme recommonmark evdev
+- pip install -r ./docs/requirements.txt
 script:
 - chmod -R g+rw ./tests/fake-sys/devices/**/*
 - ./tests/api_tests.py

--- a/docs/motors.rst
+++ b/docs/motors.rst
@@ -10,7 +10,7 @@ Motor classes
 Units
 -----
 
-Most methods which run motors with accept a ``speed`` or ``speed_pct`` argument. While this can be provided as an integer which will be interpreted as a percentage of max speed, you can also specify an instance of any of the following classes, each of which represents a different unit system:
+Most methods which run motors with accept a ``speed`` argument. While this can be provided as an integer which will be interpreted as a percentage of max speed, you can also specify an instance of any of the following classes, each of which represents a different unit system:
 
 .. autoclass:: SpeedInteger
 .. autoclass:: SpeedPercent

--- a/docs/motors.rst
+++ b/docs/motors.rst
@@ -10,9 +10,9 @@ Motor classes
 Units
 -----
 
-Most methods which run motors with accept a ``speed`` argument. While this can be provided as an integer which will be interpreted as a percentage of max speed, you can also specify an instance of any of the following classes, each of which represents a different unit system:
+Most methods which run motors will accept a ``speed`` argument. While this can be provided as an integer which will be interpreted as a percentage of max speed, you can also specify an instance of any of the following classes, each of which represents a different unit system:
 
-.. autoclass:: SpeedInteger
+.. autoclass:: SpeedValue
 .. autoclass:: SpeedPercent
 .. autoclass:: SpeedNativeUnits
 .. autoclass:: SpeedRPS

--- a/ev3dev2/motor.py
+++ b/ev3dev2/motor.py
@@ -878,9 +878,9 @@ class Motor(Device):
         assert rotations >= 0, "rotations is {}, must be >= 0".format(rotations)
 
         if speed > 0:
-            self.position_sp = self.position + int(rotations * self.count_per_rot)
+            self.position_sp = self.position + int(round(rotations * self.count_per_rot))
         else:
-            self.position_sp = self.position - int(rotations * self.count_per_rot)
+            self.position_sp = self.position - int(round(rotations * self.count_per_rot))
 
     def _set_position_degrees(self, speed, degrees):
 
@@ -1758,8 +1758,8 @@ class MoveTank(MotorSet):
             "Either left_speed or right_speed must be non-zero"
         
         return (
-            int(left_speed),
-            int(right_speed)
+            left_speed,
+            right_speed
         )
 
     def on_for_rotations(self, left_speed, right_speed, rotations, brake=True, block=True):
@@ -1785,10 +1785,10 @@ class MoveTank(MotorSet):
             right_rotations = rotations
 
         # Set all parameters
-        self.left_motor.speed_sp = left_speed_native_units
+        self.left_motor.speed_sp = int(round(left_speed_native_units))
         self.left_motor._set_position_rotations(left_speed_native_units, left_rotations)
         self.left_motor._set_brake(brake)
-        self.right_motor.speed_sp = right_speed_native_units
+        self.right_motor.speed_sp = int(round(right_speed_native_units))
         self.right_motor._set_position_rotations(right_speed_native_units, right_rotations)
         self.right_motor._set_brake(brake)
 
@@ -1819,10 +1819,10 @@ class MoveTank(MotorSet):
             right_degrees = degrees
 
         # Set all parameters
-        self.left_motor.speed_sp = left_speed_native_units
+        self.left_motor.speed_sp = int(round(left_speed_native_units))
         self.left_motor._set_position_degrees(left_speed_native_units, left_degrees)
         self.left_motor._set_brake(brake)
-        self.right_motor.speed_sp = right_speed_native_units
+        self.right_motor.speed_sp = int(round(right_speed_native_units))
         self.right_motor._set_position_degrees(right_speed_native_units, right_degrees)
         self.right_motor._set_brake(brake)
 
@@ -1841,10 +1841,10 @@ class MoveTank(MotorSet):
         (left_speed_native_units, right_speed_native_units) = self._unpack_speeds_to_native_units(left_speed, right_speed)
 
         # Set all parameters
-        self.left_motor.speed_sp = left_speed_native_units
+        self.left_motor.speed_sp = int(round(left_speed_native_units))
         self.left_motor.time_sp = int(seconds * 1000)
         self.left_motor._set_brake(brake)
-        self.right_motor.speed_sp = right_speed_native_units
+        self.right_motor.speed_sp = int(round(right_speed_native_units))
         self.right_motor.time_sp = int(seconds * 1000)
         self.right_motor._set_brake(brake)
 
@@ -1862,8 +1862,8 @@ class MoveTank(MotorSet):
         """
         (left_speed_native_units, right_speed_native_units) = self._unpack_speeds_to_native_units(left_speed, right_speed)
 
-        self.left_motor.speed_sp = left_speed_native_units
-        self.right_motor.speed_sp = right_speed_native_units
+        self.left_motor.speed_sp = int(round(left_speed_native_units))
+        self.right_motor.speed_sp = int(round(right_speed_native_units))
 
         # Start the motors
         self.left_motor.run_forever()

--- a/ev3dev2/motor.py
+++ b/ev3dev2/motor.py
@@ -902,7 +902,7 @@ class Motor(Device):
         """
         Rotate the motor at ``speed`` for ``rotations``
 
-        ``speed`` can be an integer percentage or a :class:`ev3dev2.motor.SpeedMeasure`
+        ``speed`` can be a percentage or a :class:`ev3dev2.motor.SpeedMeasure`
         object, enabling use of other units.
         """
         speed = self._speed_native_units(speed)
@@ -925,7 +925,7 @@ class Motor(Device):
         """
         Rotate the motor at ``speed`` for ``degrees``
 
-        ``speed`` can be an integer percentage or a :class:`ev3dev2.motor.SpeedMeasure`
+        ``speed`` can be a percentage or a :class:`ev3dev2.motor.SpeedMeasure`
         object, enabling use of other units.
         """
         speed = self._speed_native_units(speed)
@@ -948,7 +948,7 @@ class Motor(Device):
         """
         Rotate the motor at ``speed`` to ``position``
 
-        ``speed`` can be an integer percentage or a :class:`ev3dev2.motor.SpeedMeasure`
+        ``speed`` can be a percentage or a :class:`ev3dev2.motor.SpeedMeasure`
         object, enabling use of other units.
         """
         speed = self._speed_native_units(speed)
@@ -971,7 +971,7 @@ class Motor(Device):
         """
         Rotate the motor at ``speed`` for ``seconds``
 
-        ``speed`` can be an integer percentage or a :class:`ev3dev2.motor.SpeedMeasure`
+        ``speed`` can be a percentage or a :class:`ev3dev2.motor.SpeedMeasure`
         object, enabling use of other units.
         """
         speed = self._speed_native_units(speed)
@@ -994,7 +994,7 @@ class Motor(Device):
         """
         Rotate the motor at ``speed`` for forever
 
-        ``speed`` can be an integer percentage or a :class:`ev3dev2.motor.SpeedMeasure`
+        ``speed`` can be a percentage or a :class:`ev3dev2.motor.SpeedMeasure`
         object, enabling use of other units.
 
         Note that `block` is False by default, this is different from the
@@ -1765,7 +1765,7 @@ class MoveTank(MotorSet):
     def on_for_rotations(self, left_speed, right_speed, rotations, brake=True, block=True):
         """
         Rotate the motors at 'left_speed & right_speed' for 'rotations'. Speeds
-        can be integer percentages or any SpeedMeasure implementation.
+        can be percentages or any SpeedMeasure implementation.
 
         If the left speed is not equal to the right speed (i.e., the robot will
         turn), the motor on the outside of the turn will rotate for the full
@@ -1802,7 +1802,7 @@ class MoveTank(MotorSet):
     def on_for_degrees(self, left_speed, right_speed, degrees, brake=True, block=True):
         """
         Rotate the motors at 'left_speed & right_speed' for 'degrees'. Speeds
-        can be integer percentages or any SpeedMeasure implementation.
+        can be percentages or any SpeedMeasure implementation.
 
         If the left speed is not equal to the right speed (i.e., the robot will
         turn), the motor on the outside of the turn will rotate for the full
@@ -1836,7 +1836,7 @@ class MoveTank(MotorSet):
     def on_for_seconds(self, left_speed, right_speed, seconds, brake=True, block=True):
         """
         Rotate the motors at 'left_speed & right_speed' for 'seconds'. Speeds
-        can be integer percentages or any SpeedMeasure implementation.
+        can be percentages or any SpeedMeasure implementation.
         """
         (left_speed_native_units, right_speed_native_units) = self._unpack_speeds_to_native_units(left_speed, right_speed)
 
@@ -1858,7 +1858,7 @@ class MoveTank(MotorSet):
     def on(self, left_speed, right_speed):
         """
         Start rotating the motors according to ``left_speed`` and ``right_speed`` forever.
-        Speeds can be integer percentages or any SpeedMeasure implementation.
+        Speeds can be percentages or any SpeedMeasure implementation.
         """
         (left_speed_native_units, right_speed_native_units) = self._unpack_speeds_to_native_units(left_speed, right_speed)
 

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -36,6 +36,9 @@ class TestAPI(unittest.TestCase):
         with self.assertRaises(ev3dev2.DeviceNotFound):
             d = ev3dev2.Device('tacho-motor', 'motor*', address='outA', driver_name='not-valid')
 
+        with self.assertRaises(ev3dev2.DeviceNotFound):
+            d = ev3dev2.Device('tacho-motor', 'motor*', address='this-does-not-exist')
+
         d = ev3dev2.Device('lego-sensor', 'sensor*')
 
         with self.assertRaises(ev3dev2.DeviceNotFound):
@@ -162,12 +165,12 @@ class TestAPI(unittest.TestCase):
 
         m = Motor()
 
-        self.assertEqual(SpeedPercent(35).get_speed_pct(m), 35)
-        self.assertEqual(SpeedDPS(300).get_speed_pct(m), 300 / 1050 * 100)
-        self.assertEqual(SpeedNativeUnits(300).get_speed_pct(m), 300 / 1050 * 100)
-        self.assertEqual(SpeedDPM(30000).get_speed_pct(m), (30000 / 60) / 1050 * 100)
-        self.assertEqual(SpeedRPS(2).get_speed_pct(m), 360 * 2 / 1050 * 100)
-        self.assertEqual(SpeedRPM(100).get_speed_pct(m), (360 * 100 / 60) / 1050 * 100)
+        self.assertEqual(SpeedPercent(35).to_native_units(m), 35 / 100 * m.max_speed)
+        self.assertEqual(SpeedDPS(300).to_native_units(m), 300)
+        self.assertEqual(SpeedNativeUnits(300).to_native_units(m), 300)
+        self.assertEqual(SpeedDPM(30000).to_native_units(m), (30000 / 60))
+        self.assertEqual(SpeedRPS(2).to_native_units(m), 360 * 2)
+        self.assertEqual(SpeedRPM(100).to_native_units(m), (360 * 100 / 60))
 
 
 if __name__ == "__main__":

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -116,8 +116,8 @@ class TestAPI(unittest.TestCase):
         self.assertEqual(drive.left_motor.speed_sp, 1050 / 2)
 
         self.assertEqual(drive.right_motor.position, 0)
-        self.assertAlmostEqual(drive.right_motor.position_sp, 5 * 360, delta=5)
-        self.assertAlmostEqual(drive.right_motor.speed_sp, 1050 / 4, delta=1)
+        self.assertEqual(drive.right_motor.position_sp, 5 * 360)
+        self.assertAlmostEqual(drive.right_motor.speed_sp, 1050 / 4, delta=0.5)
     
     def test_tank_units(self):
         clean_arena()
@@ -131,8 +131,8 @@ class TestAPI(unittest.TestCase):
         self.assertEqual(drive.left_motor.speed_sp, 400)
 
         self.assertEqual(drive.right_motor.position, 0)
-        self.assertAlmostEqual(drive.right_motor.position_sp, 10 * 360 * ((10000 / 60) / 400), delta=7)
-        self.assertAlmostEqual(drive.right_motor.speed_sp, 10000 / 60, delta=1)
+        self.assertAlmostEqual(drive.right_motor.position_sp, 10 * 360 * ((10000 / 60) / 400))
+        self.assertAlmostEqual(drive.right_motor.speed_sp, 10000 / 60, delta=0.5)
 
     def test_steering_units(self):
         clean_arena()


### PR DESCRIPTION
- Rename `SpeedInteger` to `SpeedMeasure`
- Use an instance field rather than inheriting from `int`
- Drop `_pct` name suffix (was confusing users and doesn't have meaning much anymore)
- Use native motor units internally rather than percentages
- Update tests to be tougher on rounding (now that we only round once at the end)

Note that there is a slight breaking change here: anyone referencing the "speed_pct" argument by name will get an error. Our last release was a beta, so we aren't breaking semver by doing this (although I want to minimize breaking changes as much as possible).


Fixes #479 