### PR TITLE
Optimistically check the mode of the sensor before setting it on read

### DIFF
--- a/ev3dev2/sensor/__init__.py
+++ b/ev3dev2/sensor/__init__.py
@@ -62,19 +62,7 @@ else:
 class Sensor(Device):
     """
     The sensor class provides a uniform interface for using most of the
-    sensors available for the EV3. The various underlying device drivers will
-    create a `lego-sensor` device for interacting with the sensors.
-
-    Sensors are primarily controlled by setting the `mode` and monitored by
-    reading the `value<N>` attributes. Values can be converted to floating point
-    if needed by `value<N>` / 10.0 ^ `decimals`.
-
-    Since the name of the `sensor<N>` device node does not correspond to the port
-    that a sensor is plugged in to, you must look at the `address` attribute if
-    you need to know which port a sensor is plugged in to. However, if you don't
-    have more than one sensor of each type, you can just look for a matching
-    `driver_name`. Then it will not matter which port a sensor is plugged in to - your
-    program will still work.
+    sensors available for the EV3.
     """
 
     SYSTEM_CLASS_NAME = 'lego-sensor'
@@ -286,7 +274,10 @@ class Sensor(Device):
         if fmt is None: return raw
 
         return unpack(fmt, raw)
-
+    
+    def _ensure_mode(self, mode):
+        if self.mode != mode:
+            self.mode = mode
 
 def list_sensors(name_pattern=Sensor.SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
     """

--- a/ev3dev2/sensor/lego.py
+++ b/ev3dev2/sensor/lego.py
@@ -54,7 +54,7 @@ class TouchSensor(Sensor):
         A boolean indicating whether the current touch sensor is being
         pressed.
         """
-        self.mode = self.MODE_TOUCH
+        self._ensure_mode(self.MODE_TOUCH)
         return self.value(0)
 
     @property
@@ -182,7 +182,7 @@ class ColorSensor(Sensor):
         """
         Reflected light intensity as a percentage. Light on sensor is red.
         """
-        self.mode = self.MODE_COL_REFLECT
+        self._ensure_mode(self.MODE_COL_REFLECT)
         return self.value(0)
 
     @property
@@ -190,7 +190,7 @@ class ColorSensor(Sensor):
         """
         Ambient light intensity. Light on sensor is dimly lit blue.
         """
-        self.mode = self.MODE_COL_AMBIENT
+        self._ensure_mode(self.MODE_COL_AMBIENT)
         return self.value(0)
 
     @property
@@ -206,7 +206,7 @@ class ColorSensor(Sensor):
           - 6: White
           - 7: Brown
         """
-        self.mode = self.MODE_COL_COLOR
+        self._ensure_mode(self.MODE_COL_COLOR)
         return self.value(0)
 
     @property
@@ -226,7 +226,7 @@ class ColorSensor(Sensor):
 
         If this is an issue, check out the rgb() and calibrate_white() methods.
         """
-        self.mode = self.MODE_RGB_RAW
+        self._ensure_mode(self.MODE_RGB_RAW)
         return self.value(0), self.value(1), self.value(2)
 
     def calibrate_white(self):
@@ -384,7 +384,7 @@ class ColorSensor(Sensor):
         """
         Red component of the detected color, in the range 0-1020.
         """
-        self.mode = self.MODE_RGB_RAW
+        self._ensure_mode(self.MODE_RGB_RAW)
         return self.value(0)
 
     @property
@@ -392,7 +392,7 @@ class ColorSensor(Sensor):
         """
         Green component of the detected color, in the range 0-1020.
         """
-        self.mode = self.MODE_RGB_RAW
+        self._ensure_mode(self.MODE_RGB_RAW)
         return self.value(1)
 
     @property
@@ -400,7 +400,7 @@ class ColorSensor(Sensor):
         """
         Blue component of the detected color, in the range 0-1020.
         """
-        self.mode = self.MODE_RGB_RAW
+        self._ensure_mode(self.MODE_RGB_RAW)
         return self.value(2)
 
 
@@ -440,12 +440,12 @@ class UltrasonicSensor(Sensor):
 
     @property
     def distance_centimeters_continuous(self):
-        self.mode = self.MODE_US_DIST_CM
+        self._ensure_mode(self.MODE_US_DIST_CM)
         return self.value(0) * self._scale('US_DIST_CM')
 
     @property
     def distance_centimeters_ping(self):
-        self.mode = self.MODE_US_SI_CM
+        self._ensure_mode(self.MODE_US_SI_CM)
         return self.value(0) * self._scale('US_DIST_CM')
 
     @property
@@ -458,12 +458,12 @@ class UltrasonicSensor(Sensor):
 
     @property
     def distance_inches_continuous(self):
-        self.mode = self.MODE_US_DIST_IN
+        self._ensure_mode(self.MODE_US_DIST_IN)
         return self.value(0) * self._scale('US_DIST_IN')
 
     @property
     def distance_inches_ping(self):
-        self.mode = self.MODE_US_SI_IN
+        self._ensure_mode(self.MODE_US_SI_IN)
         return self.value(0) * self._scale('US_DIST_IN')
 
     @property
@@ -480,7 +480,7 @@ class UltrasonicSensor(Sensor):
         Value indicating whether another ultrasonic sensor could
         be heard nearby.
         """
-        self.mode = self.MODE_US_LISTEN
+        self._ensure_mode(self.MODE_US_LISTEN)
         return bool(self.value(0))
 
 
@@ -533,7 +533,7 @@ class GyroSensor(Sensor):
         The number of degrees that the sensor has been rotated
         since it was put into this mode.
         """
-        self.mode = self.MODE_GYRO_ANG
+        self._ensure_mode(self.MODE_GYRO_ANG)
         return self.value(0)
 
     @property
@@ -541,7 +541,7 @@ class GyroSensor(Sensor):
         """
         The rate at which the sensor is rotating, in degrees/second.
         """
-        self.mode = self.MODE_GYRO_RATE
+        self._ensure_mode(self.MODE_GYRO_RATE)
         return self.value(0)
 
     @property
@@ -549,21 +549,21 @@ class GyroSensor(Sensor):
         """
         Angle (degrees) and Rotational Speed (degrees/second).
         """
-        self.mode = self.MODE_GYRO_G_A
+        self._ensure_mode(self.MODE_GYRO_G_A)
         return self.value(0), self.value(1)
 
     @property
     def tilt_angle(self):
-        self.mode = self.MODE_TILT_ANG
+        self._ensure_mode(self.MODE_TILT_ANG)
         return self.value(0)
 
     @property
     def tilt_rate(self):
-        self.mode = self.MODE_TILT_RATE
+        self._ensure_mode(self.MODE_TILT_RATE)
         return self.value(0)
 
     def reset(self):
-        self.mode = self.MODE_GYRO_ANG
+        self._ensure_mode(self.MODE_GYRO_ANG)
         self._direct = self.set_attr_raw(self._direct, 'direct', 17)
 
     def wait_until_angle_changed_by(self, delta):
@@ -687,14 +687,14 @@ class InfraredSensor(Sensor, ButtonBase):
         A measurement of the distance between the sensor and the remote,
         as a percentage. 100% is approximately 70cm/27in.
         """
-        self.mode = self.MODE_IR_PROX
+        self._ensure_mode(self.MODE_IR_PROX)
         return self.value(0)
 
     def heading(self, channel=1):
         """
         Returns heading (-25, 25) to the beacon on the given channel.
         """
-        self.mode = self.MODE_IR_SEEK
+        self._ensure_mode(self.MODE_IR_SEEK)
         channel = self._normalize_channel(channel)
         return self.value(channel * 2)
 
@@ -703,7 +703,7 @@ class InfraredSensor(Sensor, ButtonBase):
         Returns distance (0, 100) to the beacon on the given channel.
         Returns None when beacon is not found.
         """
-        self.mode = self.MODE_IR_SEEK
+        self._ensure_mode(self.MODE_IR_SEEK)
         channel = self._normalize_channel(channel)
         ret_value = self.value((channel * 2) + 1)
 
@@ -751,7 +751,7 @@ class InfraredSensor(Sensor, ButtonBase):
         """
         Returns list of currently pressed buttons.
         """
-        self.mode = self.MODE_IR_REMOTE
+        self._ensure_mode(self.MODE_IR_REMOTE)
         channel = self._normalize_channel(channel)
         return self._BUTTON_VALUES.get(self.value(channel), [])
 
@@ -834,7 +834,7 @@ class SoundSensor(Sensor):
         A measurement of the measured sound pressure level, as a
         percent. Uses a flat weighting.
         """
-        self.mode = self.MODE_DB
+        self._ensure_mode(self.MODE_DB)
         return self.value(0) * self._scale('DB')
 
     @property
@@ -843,7 +843,7 @@ class SoundSensor(Sensor):
         A measurement of the measured sound pressure level, as a
         percent. Uses A-weighting, which focuses on levels up to 55 dB.
         """
-        self.mode = self.MODE_DBA
+        self._ensure_mode(self.MODE_DBA)
         return self.value(0) * self._scale('DBA')
 
 
@@ -874,7 +874,7 @@ class LightSensor(Sensor):
         """
         A measurement of the reflected light intensity, as a percentage.
         """
-        self.mode = self.MODE_REFLECT
+        self._ensure_mode(self.MODE_REFLECT)
         return self.value(0) * self._scale('REFLECT')
 
     @property
@@ -882,5 +882,5 @@ class LightSensor(Sensor):
         """
         A measurement of the ambient light intensity, as a percentage.
         """
-        self.mode = self.MODE_AMBIENT
+        self._ensure_mode(self.MODE_AMBIENT)
         return self.value(0) * self._scale('AMBIENT')

--- a/ev3dev2/sensor/lego.py
+++ b/ev3dev2/sensor/lego.py
@@ -440,12 +440,36 @@ class UltrasonicSensor(Sensor):
 
     @property
     def distance_centimeters_continuous(self):
+        """
+        Measurement of the distance detected by the sensor,
+        in centimeters.
+
+        The sensor will continue to take measurements so
+        they are available for future reads.
+
+        Prefer using the equivalent :meth:`UltrasonicSensor.distance_centimeters` property.
+        """
         self._ensure_mode(self.MODE_US_DIST_CM)
         return self.value(0) * self._scale('US_DIST_CM')
 
     @property
     def distance_centimeters_ping(self):
-        self._ensure_mode(self.MODE_US_SI_CM)
+        """
+        Measurement of the distance detected by the sensor,
+        in centimeters.
+
+        The sensor will take a single measurement then stop
+        broadcasting.
+
+        If you use this property too frequently (e.g. every
+        100msec), the sensor will sometimes lock up and writing
+        to the mode attribute will return an error. A delay of
+        250msec between each usage seems sufficient to keep the
+        sensor from locking up.
+        """
+        # This mode is special; setting the mode causes the sensor to send out
+        # a "ping", but the mode isn't actually changed.
+        self.mode = self.MODE_US_SI_CM
         return self.value(0) * self._scale('US_DIST_CM')
 
     @property
@@ -453,17 +477,43 @@ class UltrasonicSensor(Sensor):
         """
         Measurement of the distance detected by the sensor,
         in centimeters.
+
+        Equivalent to :meth:`UltrasonicSensor.distance_centimeters_continuous`.
         """
         return self.distance_centimeters_continuous
 
     @property
     def distance_inches_continuous(self):
+        """
+        Measurement of the distance detected by the sensor,
+        in inches.
+
+        The sensor will continue to take measurements so
+        they are available for future reads.
+
+        Prefer using the equivalent :meth:`UltrasonicSensor.distance_inches` property.
+        """
         self._ensure_mode(self.MODE_US_DIST_IN)
         return self.value(0) * self._scale('US_DIST_IN')
 
     @property
     def distance_inches_ping(self):
-        self._ensure_mode(self.MODE_US_SI_IN)
+        """
+        Measurement of the distance detected by the sensor,
+        in inches.
+
+        The sensor will take a single measurement then stop
+        broadcasting.
+
+        If you use this property too frequently (e.g. every
+        100msec), the sensor will sometimes lock up and writing
+        to the mode attribute will return an error. A delay of
+        250msec between each usage seems sufficient to keep the
+        sensor from locking up.
+        """
+        # This mode is special; setting the mode causes the sensor to send out
+        # a "ping", but the mode isn't actually changed.
+        self.mode = self.MODE_US_SI_IN
         return self.value(0) * self._scale('US_DIST_IN')
 
     @property
@@ -477,7 +527,7 @@ class UltrasonicSensor(Sensor):
     @property
     def other_sensor_present(self):
         """
-        Value indicating whether another ultrasonic sensor could
+        Boolean indicating whether another ultrasonic sensor could
         be heard nearby.
         """
         self._ensure_mode(self.MODE_US_LISTEN)

--- a/ev3dev2/sensor/lego.py
+++ b/ev3dev2/sensor/lego.py
@@ -760,21 +760,22 @@ class InfraredSensor(Sensor, ButtonBase):
         Check for currenly pressed buttons. If the new state differs from the
         old state, call the appropriate button event handlers.
 
-        To use the on_channel1_top_left, etc handlers your program would do something like:
+        To use the on_channel1_top_left, etc handlers your program would do something like::
 
-        def top_left_channel_1_action(state):
-            print("top left on channel 1: %s" % state)
+            def top_left_channel_1_action(state):
+                print("top left on channel 1: %s" % state)
 
-        def bottom_right_channel_4_action(state):
-            print("bottom right on channel 4: %s" % state)
+            def bottom_right_channel_4_action(state):
+                print("bottom right on channel 4: %s" % state)
 
-        ir = InfraredSensor()
-        ir.on_channel1_top_left = top_left_channel_1_action
-        ir.on_channel4_bottom_right = bottom_right_channel_4_action
+            ir = InfraredSensor()
+            ir.on_channel1_top_left = top_left_channel_1_action
+            ir.on_channel4_bottom_right = bottom_right_channel_4_action
 
-        while True:
-            ir.process()
-            time.sleep(0.01)
+            while True:
+                ir.process()
+                time.sleep(0.01)
+        
         """
         new_state = []
         state_diff = []

--- a/ev3dev2/sensor/lego.py
+++ b/ev3dev2/sensor/lego.py
@@ -521,6 +521,8 @@ class UltrasonicSensor(Sensor):
         """
         Measurement of the distance detected by the sensor,
         in inches.
+
+        Equivalent to :meth:`UltrasonicSensor.distance_inches_continuous`.
         """
         return self.distance_inches_continuous
 
@@ -694,33 +696,48 @@ class InfraredSensor(Sensor, ButtonBase):
     TOP_LEFT_BOTTOM_LEFT = 10
     TOP_RIGHT_BOTTOM_RIGHT = 11
 
-    # See process() for an explanation on how to use these
-    #: Handles ``Red Up``, etc events on channel 1
+    #: Handler for top-left button events on channel 1. See :meth:`InfraredSensor.process`.
     on_channel1_top_left = None
+    #: Handler for bottom-left button events on channel 1. See :meth:`InfraredSensor.process`.
     on_channel1_bottom_left = None
+    #: Handler for top-right button events on channel 1. See :meth:`InfraredSensor.process`.
     on_channel1_top_right = None
+    #: Handler for bottom-right button events on channel 1. See :meth:`InfraredSensor.process`.
     on_channel1_bottom_right = None
+    #: Handler for beacon button events on channel 1. See :meth:`InfraredSensor.process`.
     on_channel1_beacon = None
 
-    #: Handles ``Red Up``, etc events on channel 2
+    #: Handler for top-left button events on channel 2. See :meth:`InfraredSensor.process`.
     on_channel2_top_left = None
+    #: Handler for bottom-left button events on channel 2. See :meth:`InfraredSensor.process`.
     on_channel2_bottom_left = None
+    #: Handler for top-right button events on channel 2. See :meth:`InfraredSensor.process`.
     on_channel2_top_right = None
+    #: Handler for bottom-right button events on channel 2. See :meth:`InfraredSensor.process`.
     on_channel2_bottom_right = None
+    #: Handler for beacon button events on channel 2. See :meth:`InfraredSensor.process`.
     on_channel2_beacon = None
 
-    #: Handles ``Red Up``, etc events on channel 3
+    #: Handler for top-left button events on channel 3. See :meth:`InfraredSensor.process`.
     on_channel3_top_left = None
+    #: Handler for bottom-left button events on channel 3. See :meth:`InfraredSensor.process`.
     on_channel3_bottom_left = None
+    #: Handler for top-right button events on channel 3. See :meth:`InfraredSensor.process`.
     on_channel3_top_right = None
+    #: Handler for bottom-right button events on channel 3. See :meth:`InfraredSensor.process`.
     on_channel3_bottom_right = None
+    #: Handler for beacon button events on channel 3. See :meth:`InfraredSensor.process`.
     on_channel3_beacon = None
 
-    #: Handles ``Red Up``, etc events on channel 4
+    #: Handler for top-left button events on channel 4. See :meth:`InfraredSensor.process`.
     on_channel4_top_left = None
+    #: Handler for bottom-left button events on channel 4. See :meth:`InfraredSensor.process`.
     on_channel4_bottom_left = None
+    #: Handler for top-right button events on channel 4. See :meth:`InfraredSensor.process`.
     on_channel4_top_right = None
+    #: Handler for bottom-right button events on channel 4. See :meth:`InfraredSensor.process`.
     on_channel4_bottom_right = None
+    #: Handler for beacon button events on channel 4. See :meth:`InfraredSensor.process`.
     on_channel4_beacon = None
 
     def __init__(self, address=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, name_exact=False, **kwargs):
@@ -769,31 +786,31 @@ class InfraredSensor(Sensor, ButtonBase):
 
     def top_left(self, channel=1):
         """
-        Checks if `top_left` button is pressed.
+        Checks if ``top_left`` button is pressed.
         """
         return 'top_left' in self.buttons_pressed(channel)
 
     def bottom_left(self, channel=1):
         """
-        Checks if `bottom_left` button is pressed.
+        Checks if ``bottom_left`` button is pressed.
         """
         return 'bottom_left' in self.buttons_pressed(channel)
 
     def top_right(self, channel=1):
         """
-        Checks if `top_right` button is pressed.
+        Checks if ``top_right`` button is pressed.
         """
         return 'top_right' in self.buttons_pressed(channel)
 
     def bottom_right(self, channel=1):
         """
-        Checks if `bottom_right` button is pressed.
+        Checks if ``bottom_right`` button is pressed.
         """
         return 'bottom_right' in self.buttons_pressed(channel)
 
     def beacon(self, channel=1):
         """
-        Checks if `beacon` button is pressed.
+        Checks if ``beacon`` button is pressed.
         """
         return 'beacon' in self.buttons_pressed(channel)
 
@@ -810,7 +827,9 @@ class InfraredSensor(Sensor, ButtonBase):
         Check for currenly pressed buttons. If the new state differs from the
         old state, call the appropriate button event handlers.
 
-        To use the on_channel1_top_left, etc handlers your program would do something like::
+        To use the on_channel1_top_left, etc handlers your program would do something like:
+        
+        .. code:: python
 
             def top_left_channel_1_action(state):
                 print("top left on channel 1: %s" % state)

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -93,6 +93,19 @@ class TestAPI(unittest.TestCase):
         self.assertEqual(s.num_values,      1)
         self.assertEqual(s.address,         'in1')
         self.assertEqual(s.value(0),        16)
+        self.assertEqual(s.mode,            "IR-PROX")
+
+        s.mode = "IR-REMOTE"
+        self.assertEqual(s.mode,            "IR-REMOTE")
+
+        val = s.proximity
+        # Our test environment writes to actual files on disk, so while "seek(0) write(...)" works on the real device, it leaves trailing characters from previous writes in tests. "s.mode" returns "IR-PROXTE" here.
+        self.assertTrue(s.mode.startswith("IR-PROX"))
+        self.assertEqual(val,               16)
+
+        val = s.buttons_pressed()
+        self.assertTrue(s.mode.startswith("IR-REMOTE"))
+        self.assertEqual(val,               [])
 
     def test_medium_motor_write(self):
         clean_arena()
@@ -171,7 +184,6 @@ class TestAPI(unittest.TestCase):
         self.assertEqual(SpeedDPM(30000).to_native_units(m), (30000 / 60))
         self.assertEqual(SpeedRPS(2).to_native_units(m), 360 * 2)
         self.assertEqual(SpeedRPM(100).to_native_units(m), (360 * 100 / 60))
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
As we've [recently discovered](https://github.com/ev3dev/ev3dev-lang-python/issues/498), some sensors don't respond well to having their mode set repeatedly<sup>1</sup>. Here's my proposed fix, which I think simultaneously improves sensor operation all-around.

<sup>1: _My guess is that this was intentional on LEGO's part; the beacon button in particular has a delay on it, presumably added on the sensor side to be resilient to momentary losses of line-of-sight. That timer is probably reset every time we write the mode._</sup>

---

I did some benchmarking with an IR sensor (UART):

```
robot@ev3dev:~/ev3dev-lang-python$ python3 -m timeit -s "import ev3dev2.sensor; s = ev3dev2.sensor.Sensor(ev3dev2.sensor.INPUT_3)" "s.mode"
1000 loops, best of 3: 975 usec per loop

robot@ev3dev:~/ev3dev-lang-python$ python3 -m timeit -s "import ev3dev2.sensor; s = ev3dev2.sensor.Sensor(ev3dev2.sensor.INPUT_3)" "s.mode = 'IR-REMOTE'"
10 loops, best of 3: 97.8 msec per loop
```

In other words, reading the mode takes around 1ms, and writing takes 100x that. This is generally what I would expect, given that setting the mode on a UART sensor always requires writing to the serial line and might even wait for a response... I haven't looked into it past a cursory glance at the top-level "set" method. I believe reading is just a memory read (+ sysfs overhead).

For comparison, here's an analog sensor (the only one IIRC), which only has one mode and presumably no-ops when setting the mode anyway (I didn't bother looking up the driver code for this one):

```
robot@ev3dev:~/ev3dev-lang-python$ python3 -m timeit -s "import ev3dev2.sensor; s = ev3dev2.sensor.Sensor(ev3dev2.sensor.INPUT_3)" "s.mode"
1000 loops, best of 3: 834 usec per loop

robot@ev3dev:~/ev3dev-lang-python$ python3 -m timeit -s "import ev3dev2.sensor; s = ev3dev2.sensor.Sensor(ev3dev2.sensor.INPUT_3)" "s.mode = 'TOUCH'"
1000 loops, best of 3: 827 usec per loop
````

So, this one is around 1ms for both operations. I'm going to guess that this is just sysfs file I/O overhead.

I didn't see much use in finding an I2C sensor, given that pretty much all of the EV3 ones are UART. It's probably somewhere in between.

---

What this tells me is that we wait 100ms every time you read a sensor, for no good reason. Given that reading the mode is only 1ms, it seems reasonable to me that we should do the read and only write if we need it to change. In most cases, that's probably the right assumption. Technically, this does introduce a potential race condition, but I think the risk is minor.

 I've included that in this PR, and added some related tests.

Fixes #498 