### PR TITLE
Fixed MoveSteering error when steering value is >50 or <-50, degrees …

### DIFF
--- a/ev3dev2/motor.py
+++ b/ev3dev2/motor.py
@@ -1808,9 +1808,9 @@ class MoveTank(MotorSet):
 
         if left_speed_native_units > right_speed_native_units:
             left_degrees = degrees
-            right_degrees = float(right_speed / left_speed_native_units) * degrees
+            right_degrees = abs( float(right_speed_native_units / left_speed_native_units) * degrees )
         else:
-            left_degrees = float(left_speed_native_units / right_speed_native_units) * degrees
+            left_degrees = abs( float(left_speed_native_units / right_speed_native_units) * degrees )
             right_degrees = degrees
 
         # Set all parameters


### PR DESCRIPTION
Fix a problem where MoveSteering.on_for_degrees() with steering values larger than 50 or smaller than -50 caused negative degrees to be calculated, leading to an assert.  Just used abs() on the calculated degrees, the negative speed takes care of the direction.