### PR TITLE
Flexible relative movement and improved parameter handling

### DIFF
--- a/ev3dev2/motor.py
+++ b/ev3dev2/motor.py
@@ -1808,9 +1808,9 @@ class MoveTank(MotorSet):
 
         if left_speed_native_units > right_speed_native_units:
             left_degrees = degrees
-            right_degrees = float(right_speed / left_speed_native_units) * degrees
+            right_degrees = abs(float(right_speed_native_units / left_speed_native_units) * degrees)
         else:
-            left_degrees = float(left_speed_native_units / right_speed_native_units) * degrees
+            left_degrees = abs(float(left_speed_native_units / right_speed_native_units) * degrees)
             right_degrees = degrees
 
         # Set all parameters

--- a/ev3dev2/motor.py
+++ b/ev3dev2/motor.py
@@ -1752,12 +1752,12 @@ class MoveTank(MotorSet):
         # v_l = d_l/t, v_r = d_r/t
         # therefore, t = d_l/v_l = d_r/v_r
 
-        # TODO: this is wrong. consider negatives.
-        if left_speed_native_units > right_speed_native_units:
+        # larger speed by magnitude is the "outer" wheel, and rotates the full "rotations"
+        if abs(left_speed_native_units) > abs(right_speed_native_units):
             left_rotations = rotations
-            right_rotations = abs(float(right_speed_native_units / left_speed_native_units)) * rotations
+            right_rotations = abs(right_speed_native_units / left_speed_native_units) * rotations
         else:
-            left_rotations = abs(float(left_speed_native_units / right_speed_native_units)) * rotations
+            left_rotations = abs(left_speed_native_units / right_speed_native_units) * rotations
             right_rotations = rotations
 
         # Set all parameters
@@ -1786,11 +1786,12 @@ class MoveTank(MotorSet):
         """
         (left_speed_native_units, right_speed_native_units) = self._unpack_speeds_to_native_units(left_speed, right_speed)
 
-        if left_speed_native_units > right_speed_native_units:
+        # larger speed by magnitude is the "outer" wheel, and rotates the full "degrees"
+        if abs(left_speed_native_units) > abs(right_speed_native_units):
             left_degrees = degrees
-            right_degrees = abs(float(right_speed_native_units / left_speed_native_units)) * degrees
+            right_degrees = abs(right_speed_native_units / left_speed_native_units) * degrees
         else:
-            left_degrees = abs(float(left_speed_native_units / right_speed_native_units)) * degrees
+            left_degrees = abs(left_speed_native_units / right_speed_native_units) * degrees
             right_degrees = degrees
 
         # Set all parameters

--- a/ev3dev2/motor.py
+++ b/ev3dev2/motor.py
@@ -803,13 +803,13 @@ class Motor(Device):
             self._poll.register(self._state, select.POLLPRI)
 
         while True:
+            if cond(self.state):
+                return True
+            
             self._poll.poll(None if timeout is None else timeout)
 
             if timeout is not None and time.time() >= tic + timeout / 1000:
                 return False
-
-            if cond(self.state):
-                return True
 
     def wait_until_not_moving(self, timeout=None):
         """

--- a/ev3dev2/motor.py
+++ b/ev3dev2/motor.py
@@ -1758,20 +1758,16 @@ class MoveTank(MotorSet):
         ``degrees`` while the motor on the inside will have its requested
         distance calculated according to the expected turn.
         """
-
-        if left_speed == 0 and right_speed == 0 and degrees != 0:
-            raise ValueError("Can't travel a nonzero distance at zero speed")
-
         (left_speed_native_units, right_speed_native_units) = self._unpack_speeds_to_native_units(left_speed, right_speed)
 
         # proof of the following distance calculation: consider the circle formed by each wheel's path
         # v_l = d_l/t, v_r = d_r/t
         # therefore, t = d_l/v_l = d_r/v_r
-
+        
+        if degrees == 0 or (left_speed_native_units == 0 and right_speed_native_units == 0):
+            left_degrees = degrees
+            right_degrees = degrees
         # larger speed by magnitude is the "outer" wheel, and rotates the full "degrees"
-        if degrees == 0:
-            left_degrees = 0
-            right_degrees = 0
         elif abs(left_speed_native_units) > abs(right_speed_native_units):
             left_degrees = degrees
             right_degrees = abs(right_speed_native_units / left_speed_native_units) * degrees

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -172,6 +172,21 @@ class TestAPI(unittest.TestCase):
         self.assertEqual(drive.right_motor.position, 0)
         self.assertEqual(drive.right_motor.position_sp, 5 * 360)
         self.assertEqual(drive.right_motor.speed_sp, 200)
+    
+    def test_steering_large_value(self):
+        clean_arena()
+        populate_arena([('large_motor', 0, 'outA'), ('large_motor', 1, 'outB')])
+
+        drive = MoveSteering(OUTPUT_A, OUTPUT_B)
+        drive.on_for_rotations(-100, SpeedDPS(400), 10)
+
+        self.assertEqual(drive.left_motor.position, 0)
+        self.assertEqual(drive.left_motor.position_sp, 10 * 360)
+        self.assertEqual(drive.left_motor.speed_sp, -400)
+
+        self.assertEqual(drive.right_motor.position, 0)
+        self.assertEqual(drive.right_motor.position_sp, 10 * 360)
+        self.assertEqual(drive.right_motor.speed_sp, 400)
 
     def test_joystick_units(self):
         clean_arena()

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -11,7 +11,11 @@ from clean_arena    import clean_arena
 
 import ev3dev2
 from ev3dev2.sensor.lego import InfraredSensor
-from ev3dev2.motor import Motor, MediumMotor, MoveTank, MoveSteering, MoveJoystick, SpeedPercent, SpeedDPM, SpeedDPS, SpeedRPM, SpeedRPS, SpeedNativeUnits, OUTPUT_A, OUTPUT_B
+from ev3dev2.motor import \
+    Motor, MediumMotor, LargeMotor, \
+    MoveTank, MoveSteering, MoveJoystick, \
+    SpeedPercent, SpeedDPM, SpeedDPS, SpeedRPM, SpeedRPS, SpeedNativeUnits, \
+    OUTPUT_A, OUTPUT_B
 
 ev3dev2.Device.DEVICE_ROOT_PATH = os.path.join(FAKE_SYS, 'arena')
 
@@ -128,11 +132,78 @@ class TestAPI(unittest.TestCase):
         m.speed_sp = 500
         self.assertEqual(m.speed_sp, 500)
 
+    def test_motor_on_for_degrees(self):
+        clean_arena()
+        populate_arena([('large_motor', 0, 'outA')])
+
+        m = LargeMotor()
+
+        # simple case
+        m.on_for_degrees(75, 100)
+        self.assertEqual(m.speed_sp, int(round(0.75 * 1050)))
+        self.assertEqual(m.position_sp, 100)
+    
+        # various negative cases; values act like multiplication
+        m.on_for_degrees(-75, 100)
+        self.assertEqual(m.speed_sp, int(round(0.75 * 1050)))
+        self.assertEqual(m.position_sp, -100)
+        
+        m.on_for_degrees(75, -100)
+        self.assertEqual(m.speed_sp, int(round(0.75 * 1050)))
+        self.assertEqual(m.position_sp, -100)
+        
+        m.on_for_degrees(-75, -100)
+        self.assertEqual(m.speed_sp, int(round(0.75 * 1050)))
+        self.assertEqual(m.position_sp, 100)
+
+        # zero speed (on-device, this will return immediately due to reported stall)
+        m.on_for_degrees(0, 100)
+        self.assertEqual(m.speed_sp, 0)
+        self.assertEqual(m.position_sp, 100)
+        
+        # zero distance
+        m.on_for_degrees(75, 0)
+        self.assertEqual(m.speed_sp, int(round(0.75 * 1050)))
+        self.assertEqual(m.position_sp, 0)
+
+        # zero speed and distance
+        m.on_for_degrees(0, 0)
+        self.assertEqual(m.speed_sp, 0)
+        self.assertEqual(m.position_sp, 0)
+
+        # None speed
+        with self.assertRaises(ValueError):
+            m.on_for_degrees(None, 100)
+        
+        # None distance
+        with self.assertRaises(ValueError):
+            m.on_for_degrees(75, None)
+    
+    def test_motor_on_for_rotations(self):
+        clean_arena()
+        populate_arena([('large_motor', 0, 'outA')])
+
+        m = LargeMotor()
+
+        # simple case
+        m.on_for_rotations(75, 5)
+        self.assertEqual(m.speed_sp, int(round(0.75 * 1050)))
+        self.assertEqual(m.position_sp, 5 * 360)
+
+        # None speed
+        with self.assertRaises(ValueError):
+            m.on_for_rotations(None, 5)
+        
+        # None distance
+        with self.assertRaises(ValueError):
+            m.on_for_rotations(75, None)
+
     def test_move_tank(self):
         clean_arena()
         populate_arena([('large_motor', 0, 'outA'), ('large_motor', 1, 'outB')])
 
         drive = MoveTank(OUTPUT_A, OUTPUT_B)
+
         drive.on_for_rotations(50, 25, 10)
 
         self.assertEqual(drive.left_motor.position, 0)
@@ -181,8 +252,8 @@ class TestAPI(unittest.TestCase):
         drive.on_for_rotations(-100, SpeedDPS(400), 10)
 
         self.assertEqual(drive.left_motor.position, 0)
-        self.assertEqual(drive.left_motor.position_sp, 10 * 360)
-        self.assertEqual(drive.left_motor.speed_sp, -400)
+        self.assertEqual(drive.left_motor.position_sp, -10 * 360)
+        self.assertEqual(drive.left_motor.speed_sp, 400)
 
         self.assertEqual(drive.right_motor.position, 0)
         self.assertEqual(drive.right_motor.position_sp, 10 * 360)

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -240,8 +240,11 @@ class TestAPI(unittest.TestCase):
         self.assertAlmostEqual(drive.right_motor.speed_sp, 0.25 * 1050, delta=0.5)
 
         # both speeds zero but nonzero distance
-        with self.assertRaises(ValueError):
-            drive.on_for_rotations(0, 0, 10)
+        drive.on_for_rotations(0, 0, 10)
+        self.assertEqual(drive.left_motor.position_sp, 10 * 360)
+        self.assertAlmostEqual(drive.left_motor.speed_sp, 0)
+        self.assertEqual(drive.right_motor.position_sp, 10 * 360)
+        self.assertAlmostEqual(drive.right_motor.speed_sp, 0)
         
         # zero distance
         drive.on_for_rotations(25, 50, 0)


### PR DESCRIPTION
The primary goals here were to:
- Remove unnecessary cases where we warn or throw an error
- Make handling of negative speeds and distances intuitive/logical, like multiplication
- Fix cases of zero distance and/or speed

In the process, I:
- Refactored `_set_position_rotations` and `_set_position_degrees`
  - To minimize duplication there is now only one, which operates on degrees, and rotations-based methods call the degree versions. This is one more function call (which is slow) but I figure it's worth it.
  - The method is called `_set_rel_position_degrees_and_speed_sp` and handles setting both `position_sp` _and_ `speed_sp` so it can normalize negatives
- Replaced our custom `position_sp = position + delta; command = 'run-to-abs-pos'` with using `run-to-rel-pos`. I read through #360 where this was originally implemented, and don't see why it was done this way. (let me know if I missed something, @dwalton76)
- Updated the logic to choose distances for each motor so that it correctly handles negative speeds
- Removed a warning that really wasn't helpful
 
One question: On an individual motor, if you ask it to move a nonzero distance at zero speed, it will return immediately because the driver calls that a "stalling" state. However, with a motor pair, I adopted a different behavior: in that particular case it throws a `ValueError`. Do others agree with this set of behaviors or should one of them be changed?

Closes #516 (supersedes changes)
Fixes #504 
Fixes #505
Fixes #507 