### PR TITLE
suppress unittest ResourceWarning messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ install:
 - if [ $USE_MICROPYTHON = true ]; then ./.travis/install-micropython.sh && PYTHON=~/micropython/ports/unix/micropython; else PYTHON=python3; fi
 script:
 - chmod -R g+rw ./tests/fake-sys/devices/**/*
-- $PYTHON tests/api_tests.py
+- if [ $USE_MICROPYTHON = false ]; then $PYTHON -W ignore tests/api_tests.py; fi
+- if [ $USE_MICROPYTHON = true ]; then $PYTHON tests/api_tests.py; fi
 - if [ $USE_MICROPYTHON = false ]; then sphinx-build -nW -b html ./docs/ ./docs/_build/html; fi
 deploy:
   provider: pypi

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,6 @@
 python-ev3dev2 (2.0.0~beta3) stable; urgency=medium
 
+  * suppress unittest ResourceWarning messages
   * MoveJoyStick should use SpeedPercent
   * renamed GyroSensor rate_and_angle to angle_and_rate
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -8,20 +8,13 @@ already cloned the ev3dev-lang-python repo you can use the `--recursive` option
 when you git clone.  Example:
 
 ```
-$ git clone --recursive https://github.com/rhempel/ev3dev-lang-python.git
+$ git clone --recursive https://github.com/ev3dev/ev3dev-lang-python.git
 ```
 
 # Running Tests
 To run the tests do:
 ```
-$ ./api_tests.py
-```
-
-# Misc
-Commands used to copy the /sys/class node:
-
-```
-$ node=lego-sensor/sensor0
-$ mkdir -p ./${node}
-$ cp -P --copy-contents -r /sys/class/${node}/* ./${node}/
+$ cd ev3dev-lang-python/
+$ chmod -R g+rw ./tests/fake-sys/devices/**/*
+$ python3 -W ignore ./tests/api_tests.py
 ```

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -43,6 +43,14 @@ def dummy_wait(self, cond, timeout=None):
 Motor.wait = dummy_wait
 
 class TestAPI(unittest.TestCase):
+
+    def setUp(self):
+        # micropython does not have _testMethodName
+        try:
+            print("\n\n{}\n{}".format(self._testMethodName, "=" * len(self._testMethodName,)))
+        except AttributeError:
+            pass
+
     def test_device(self):
         clean_arena()
         populate_arena([('medium_motor', 0, 'outA'), ('infrared_sensor', 0, 'in1')])

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -14,8 +14,11 @@ from ev3dev2.sensor.lego import InfraredSensor
 from ev3dev2.motor import \
     Motor, MediumMotor, LargeMotor, \
     MoveTank, MoveSteering, MoveJoystick, \
-    SpeedPercent, SpeedDPM, SpeedDPS, SpeedRPM, SpeedRPS, SpeedNativeUnits, \
-    OUTPUT_A, OUTPUT_B
+    SpeedPercent, SpeedDPM, SpeedDPS, SpeedRPM, SpeedRPS, SpeedNativeUnits
+
+# We force OUTPUT_A and OUTPUT_B to be imported from platform "fake" so that
+# we can run these test cases on an EV3, brickpi3, etc.
+from ev3dev2._platform.fake import OUTPUT_A, OUTPUT_B
 
 ev3dev2.Device.DEVICE_ROOT_PATH = os.path.join(FAKE_SYS, 'arena')
 


### PR DESCRIPTION
For issue #433 

This does not fix the issue of the filehandles being left open it just suppresses the warnings generated by unittest.  We've had 433 open for almost a year and haven't come up with a good solution and leaving the filehandles open isn't really causing any issues (none that I know of at least).  From googling these unittest ResourceWarning messages we would not be the first repo to just ignore these via a warnings filter.

The ``setUp()`` method just makes it so you can tell what output is coming from what test (this is optional)

new output
```
Import warning: Failed to import "evdev". Button will be unusable!


test_device
===========
	0	outA	./tests/fake-sys/arena/tacho-motor/motor0
	0	in1	./tests/fake-sys/arena/lego-sensor/sensor0
.

test_infrared_sensor
====================
	0	in1	./tests/fake-sys/arena/lego-sensor/sensor0
.

test_joystick_units
===================
	0	outA	./tests/fake-sys/arena/tacho-motor/motor0
	1	outB	./tests/fake-sys/arena/tacho-motor/motor1
.

test_medium_motor
=================
	0	outA	./tests/fake-sys/arena/tacho-motor/motor0
.

test_medium_motor_write
=======================
	0	outA	./tests/fake-sys/arena/tacho-motor/motor0
.

test_motor_on_for_degrees
=========================
	0	outA	./tests/fake-sys/arena/tacho-motor/motor0
.

test_motor_on_for_rotations
===========================
	0	outA	./tests/fake-sys/arena/tacho-motor/motor0
.

test_move_tank_relative_distance
================================
	0	outA	./tests/fake-sys/arena/tacho-motor/motor0
	1	outB	./tests/fake-sys/arena/tacho-motor/motor1
.

test_steering_large_value
=========================
	0	outA	./tests/fake-sys/arena/tacho-motor/motor0
	1	outB	./tests/fake-sys/arena/tacho-motor/motor1
.

test_steering_units
===================
	0	outA	./tests/fake-sys/arena/tacho-motor/motor0
	1	outB	./tests/fake-sys/arena/tacho-motor/motor1
.

test_tank_units
===============
	0	outA	./tests/fake-sys/arena/tacho-motor/motor0
	1	outB	./tests/fake-sys/arena/tacho-motor/motor1
.

test_units
==========
	0	outA	./tests/fake-sys/arena/tacho-motor/motor0
	1	outB	./tests/fake-sys/arena/tacho-motor/motor1
.
----------------------------------------------------------------------
Ran 12 tests in 0.082s

OK
```