### PR TITLE
Use specific filter to ignore only ResourceWarnings in test runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ git:
   depth: 100
 install:
 - if [ $USE_MICROPYTHON = false ]; then pip install Pillow Sphinx sphinx_bootstrap_theme recommonmark evdev==1.0.0 && pip install -r ./docs/requirements.txt; fi
-- if [ $USE_MICROPYTHON = true ]; then ./.travis/install-micropython.sh && PYTHON=~/micropython/ports/unix/micropython; else PYTHON=python3; fi
+- if [ $USE_MICROPYTHON = true ]; then ./.travis/install-micropython.sh && MICROPYTHON=~/micropython/ports/unix/micropython; fi
 script:
 - chmod -R g+rw ./tests/fake-sys/devices/**/*
-- if [ $USE_MICROPYTHON = false ]; then $PYTHON -W ignore tests/api_tests.py; fi
-- if [ $USE_MICROPYTHON = true ]; then $PYTHON tests/api_tests.py; fi
+- if [ $USE_MICROPYTHON = false ]; then python3 -W ignore::ResourceWarning tests/api_tests.py; fi
+- if [ $USE_MICROPYTHON = true ]; then $MICROPYTHON tests/api_tests.py; fi
 - if [ $USE_MICROPYTHON = false ]; then sphinx-build -nW -b html ./docs/ ./docs/_build/html; fi
 deploy:
   provider: pypi

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,10 +11,28 @@ when you git clone.  Example:
 $ git clone --recursive https://github.com/ev3dev/ev3dev-lang-python.git
 ```
 
-# Running Tests
-To run the tests do:
+# Running Tests with CPython (default)
+To run the tests:
 ```
 $ cd ev3dev-lang-python/
 $ chmod -R g+rw ./tests/fake-sys/devices/**/*
-$ python3 -W ignore ./tests/api_tests.py
+$ python3 -W ignore::ResourceWarning tests/api_tests.py
+```
+
+If not on a Linux platform, the `chmod` command can be ignored.
+
+# Running Tests with Micropython
+
+This library also supports a subset of functionality on [Micropython](http://micropython.org/).
+
+You can follow the instructions on [the Micropython wiki](https://github.com/micropython/micropython/wiki/Getting-Started)
+or check out our [installation script for Travis CI workers](https://github.com/ev3dev/ev3dev-lang-python/blob/ev3dev-stretch/.travis/install-micropython.sh)
+to get Micropython installed. If following the official instructions,
+make sure you install the relevant micropython-lib modules as well.
+
+Once Micropython is installed, you can run the tests with:
+
+```
+$ cd ev3dev-lang-python/
+$ micropython tests/api_tests.py
 ```

--- a/tests/README.md
+++ b/tests/README.md
@@ -19,7 +19,7 @@ $ chmod -R g+rw ./tests/fake-sys/devices/**/*
 $ python3 -W ignore::ResourceWarning tests/api_tests.py
 ```
 
-If not on a Linux platform, the `chmod` command can be ignored.
+If on Windows, the `chmod` command can be ignored.
 
 # Running Tests with Micropython
 
@@ -28,7 +28,7 @@ This library also supports a subset of functionality on [Micropython](http://mic
 You can follow the instructions on [the Micropython wiki](https://github.com/micropython/micropython/wiki/Getting-Started)
 or check out our [installation script for Travis CI workers](https://github.com/ev3dev/ev3dev-lang-python/blob/ev3dev-stretch/.travis/install-micropython.sh)
 to get Micropython installed. If following the official instructions,
-make sure you install the relevant micropython-lib modules as well.
+make sure you install the relevant micropython-lib modules listed in the linked script as well.
 
 Once Micropython is installed, you can run the tests with:
 


### PR DESCRIPTION
Suggested change from https://github.com/ev3dev/ev3dev-lang-python/pull/556#discussion_r230610192.

Reference: https://docs.python.org/3.5/using/cmdline.html#cmdoption-w