### PR TITLE
motors.py: added missing parameter 'motors' to MotorSet.is_stalled

### DIFF
--- a/ev3dev2/motor.py
+++ b/ev3dev2/motor.py
@@ -1737,7 +1737,7 @@ class MotorSet(object):
         return self._is_state(motors, LargeMotor.STATE_OVERLOADED)
 
     @property
-    def is_stalled(self):
+    def is_stalled(self, motors=None):
         return self._is_state(motors, LargeMotor.STATE_STALLED)
 
     def wait(self, cond, timeout=None, motors=None):


### PR DESCRIPTION
I noticed that something like

```
m = MoveTank(...)
m.is_stalled()
```

fails while e.g. `m.is_overloaded()` works. I looked up the appropriate method and found a missing parameter (motors=None) which was the reason for the error.
This PR will fix this issue by adding the missing parameter.