### PR TITLE
Replace deprecated pip call with launching in separate process 

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,10 +23,7 @@ from git_version import git_version
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 if on_rtd:
-    import pip
-    pip.main(['install', 'sphinx_bootstrap_theme'])
-    pip.main(['install', 'recommonmark'])
-    pip.main(['install', 'evdev'])
+    subprocess.check_call([sys.executable, '-m', 'pip', 'install', 'sphinx_bootstrap_theme', 'recommonmark', 'evdev'])
 
 import sphinx_bootstrap_theme
 from recommonmark.parser import CommonMarkParser
@@ -325,6 +322,7 @@ nitpick_ignore = [
     ('py:class', 'tuple'),
     ('py:class', 'list'),
     ('py:exc', 'ValueError')
+    
 ]
 
 def setup(app):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -323,7 +323,6 @@ nitpick_ignore = [
     ('py:class', 'tuple'),
     ('py:class', 'list'),
     ('py:exc', 'ValueError')
-    
 ]
 
 def setup(app):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,7 @@
 import sys
 import os
 import shlex
+import subprocess
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from git_version import git_version


### PR DESCRIPTION
It looks like `pip.main` was deprecated, so our docs builds were failing after the environment upgraded to pip `10.0` where that method was removed. Replaced that call with recommended approach from https://pip.pypa.io/en/latest/user_guide/#using-pip-from-your-program. Docs builds pass now: https://readthedocs.org/projects/python-ev3dev/builds/8295108/