### PR TITLE
Add new debian binary package for MicroPython

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-python-ev3dev2 (2.0.0~beta3) stable; urgency=medium
+python-ev3dev2 (2.0.0~beta3) UNRELEASED; urgency=medium
 
   [Daniel Walton]
   * brickpi(3) support use of the Motor class
@@ -16,6 +16,9 @@ python-ev3dev2 (2.0.0~beta3) stable; urgency=medium
   * MoveJoyStick should use SpeedPercent
   * renamed GyroSensor rate_and_angle to angle_and_rate
   
+  [Kaelin Laundry]
+  * Added new binary package for Micropython
+
   [Viktor Garske]
   * Fixed error when using Motor.is_stalled
 

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: ev3dev Python team <python-team@ev3dev.org>
 Section: python
 Priority: optional
 Standards-Version: 3.9.8
-Build-Depends: python3-setuptools (>= 0.6b3), python3-all (>= 3.4), debhelper (>= 9), dh-python, python3-pillow
+Build-Depends: python3-setuptools (>= 0.6b3), python3-all (>= 3.4), debhelper (>= 9), dh-python, python3-pillow, mpy-cross
 VCS-Git: https://github.com/ev3dev/ev3dev-lang-python.git
 VCS-Browser: https://github.com/ev3dev/ev3dev-lang-python
 
@@ -15,3 +15,12 @@ Description: Python language bindings for ev3dev
  devices on hardware that is supported by ev3dev.org - a
  minimal Debian distribution optimized for the LEGO
  MINDSTORMS EV3.
+
+Package: micropython-ev3dev2
+Architecture: all
+Depends: ${misc:Depends}, micropython
+Description: Python language bindings for ev3dev for MicroPython
+ This package is a pure Python binding to the peripheral
+ devices on hardware that is supported by ev3dev.org - a
+ minimal Debian distribution optimized for the LEGO
+ MINDSTORMS EV3. This package is designed to run on MicroPython.

--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,7 @@ Description: Python language bindings for ev3dev
 
 Package: micropython-ev3dev2
 Architecture: all
-Depends: ${misc:Depends}, micropython
+Depends: ${misc:Depends}, micropython, micropython-lib
 Description: Python language bindings for ev3dev for MicroPython
  This package is a pure Python binding to the peripheral
  devices on hardware that is supported by ev3dev.org - a

--- a/debian/rules
+++ b/debian/rules
@@ -1,11 +1,60 @@
 #!/usr/bin/make -f
+#export DH_VERBOSE=1
 
-export PYBUILD_NAME=python3-ev3dev
+export PYBUILD_NAME=ev3dev2
 
 VERSION=$(shell dpkg-parsechangelog | sed -rne 's,^Version: (.*),\1,p' | sed 's,~,,')
 
+mpy_files = \
+	ev3dev2/__init__.mpy \
+	ev3dev2/_platform/__init__.mpy \
+	ev3dev2/_platform/brickpi.mpy \
+	ev3dev2/_platform/brickpi3.mpy \
+	ev3dev2/_platform/ev3.mpy \
+	ev3dev2/_platform/evb.mpy \
+	ev3dev2/_platform/fake.mpy \
+	ev3dev2/_platform/pistorms.mpy \
+	ev3dev2/auto.mpy \
+	ev3dev2/button.mpy \
+	ev3dev2/control/__init__.mpy \
+	ev3dev2/control/GyroBalancer.mpy \
+	ev3dev2/control/rc_tank.mpy \
+	ev3dev2/control/webserver.mpy \
+	ev3dev2/display.mpy \
+	ev3dev2/fonts/__init__.mpy \
+	ev3dev2/led.mpy \
+	ev3dev2/motor.mpy \
+	ev3dev2/port.mpy \
+	ev3dev2/power.mpy \
+	ev3dev2/sensor/__init__.mpy \
+	ev3dev2/sensor/lego.mpy \
+	ev3dev2/sound.mpy \
+	ev3dev2/unit.mpy \
+	ev3dev2/version.mpy \
+	ev3dev2/wheel.mpy
+
 %:
 	dh $@ --with python3 --buildsystem=pybuild
+
+%.mpy: %.py
+	mpy-cross -v -v -mcache-lookup-bc $<
+
+# compile .py > .mpy
+override_dh_auto_build: $(mpy_files)
+	# build python3 package
+	dh_auto_build
+
+# fail build if any files aren't installed into a package
+override_dh_install:
+	dh_install --fail-missing
+
+override_dh_auto_install:
+	# install python3 package
+	dh_auto_install
+	# install .mpy files for micropython
+	for d in $(mpy_files); do \
+		install -D --mode=644 $$d debian/micropython-ev3dev2/usr/lib/micropython/ev3dev2/$${d#*/}; \
+	done
 
 override_dh_auto_configure:
 	echo $(VERSION) > RELEASE-VERSION


### PR DESCRIPTION
After a bit of trial-and-error, I got a new MicroPython package building alongside our existing one. Cursory testing indicates that the new package works.

After adding the logic which copies the mpy files to their target destination then creating a `micropython-ev3dev2.install` file, it felt asymmetrical that the `python3` target was installing the files to the destination package directly while the `micropython` version was using the separate install file. So I ditched the install file and modified the loop to put the files there directly. I assume (?) that's OK.

@dlech could you look over this and validate that I didn't do anything stupid?

## Validation

No unexpected changes to the python3 package (I was quite proud that I remembered how to do the awk thing 😁):

```
robot@ev3dev:~$ dpkg -c python3-ev3dev2_2.0.0~beta3_all.deb | awk '{print $1 $6}' > beta3.txt
robot@ev3dev:~$ dpkg -c python3-ev3dev2_2.0.0~beta2_all.deb | awk '{print $1 $6}' > beta2.txt
robot@ev3dev:~$ diff beta2.txt beta3.txt
433a434
> -rw-r--r--./usr/lib/python3/dist-packages/ev3dev2/unit.py
435,439c436,441
< drwxr-xr-x./usr/lib/python3/dist-packages/python_ev3dev2-2.0.0b2.egg-info/
< -rw-r--r--./usr/lib/python3/dist-packages/python_ev3dev2-2.0.0b2.egg-info/PKG-INFO
< -rw-r--r--./usr/lib/python3/dist-packages/python_ev3dev2-2.0.0b2.egg-info/dependency_links.txt
< -rw-r--r--./usr/lib/python3/dist-packages/python_ev3dev2-2.0.0b2.egg-info/requires.txt
< -rw-r--r--./usr/lib/python3/dist-packages/python_ev3dev2-2.0.0b2.egg-info/top_level.txt
---
> -rw-r--r--./usr/lib/python3/dist-packages/ev3dev2/wheel.py
> drwxr-xr-x./usr/lib/python3/dist-packages/python_ev3dev2-2.0.0b3.egg-info/
> -rw-r--r--./usr/lib/python3/dist-packages/python_ev3dev2-2.0.0b3.egg-info/PKG-INFO
> -rw-r--r--./usr/lib/python3/dist-packages/python_ev3dev2-2.0.0b3.egg-info/dependency_links.txt
> -rw-r--r--./usr/lib/python3/dist-packages/python_ev3dev2-2.0.0b3.egg-info/requires.txt
> -rw-r--r--./usr/lib/python3/dist-packages/python_ev3dev2-2.0.0b3.egg-info/top_level.txt
```

New package works:

```
robot@ev3dev:~$ sudo dpkg -i micropython-ev3dev2_2.0.0~beta3_all.deb
(Reading database ... 47377 files and directories currently installed.)
Preparing to unpack micropython-ev3dev2_2.0.0~beta3_all.deb ...
Unpacking micropython-ev3dev2 (2.0.0~beta3) over (2.0.0~beta3) ...
Setting up micropython-ev3dev2 (2.0.0~beta3) ...
robot@ev3dev:~$ micropython
MicroPython v1.9.4 on 2018-05-22; linux version
Use Ctrl-D to exit, Ctrl-E for paste mode
>>> import ev3dev2.version
>>> print(ev3dev2.version.__version__)
2.0.0beta3
```

For reference:

```
robot@ev3dev:~$ dpkg -c micropython-ev3dev2_2.0.0~beta3_all.deb
drwxr-xr-x root/root         0 2018-10-28 04:18 ./
drwxr-xr-x root/root         0 2018-10-28 04:18 ./usr/
drwxr-xr-x root/root         0 2018-10-28 04:18 ./usr/lib/
drwxr-xr-x root/root         0 2018-10-28 04:18 ./usr/lib/micropython/
drwxr-xr-x root/root         0 2018-10-28 04:18 ./usr/lib/micropython/ev3dev2/
-rw-r--r-- root/root      7474 2018-10-28 04:18 ./usr/lib/micropython/ev3dev2/__init__.mpy
drwxr-xr-x root/root         0 2018-10-28 04:18 ./usr/lib/micropython/ev3dev2/_platform/
-rw-r--r-- root/root        62 2018-10-28 04:18 ./usr/lib/micropython/ev3dev2/_platform/__init__.mpy
-rw-r--r-- root/root       733 2018-10-28 04:18 ./usr/lib/micropython/ev3dev2/_platform/brickpi.mpy
-rw-r--r-- root/root      1239 2018-10-28 04:18 ./usr/lib/micropython/ev3dev2/_platform/brickpi3.mpy
-rw-r--r-- root/root      1073 2018-10-28 04:18 ./usr/lib/micropython/ev3dev2/_platform/ev3.mpy
-rw-r--r-- root/root       369 2018-10-28 04:18 ./usr/lib/micropython/ev3dev2/_platform/evb.mpy
-rw-r--r-- root/root       308 2018-10-28 04:18 ./usr/lib/micropython/ev3dev2/_platform/fake.mpy
-rw-r--r-- root/root      1260 2018-10-28 04:18 ./usr/lib/micropython/ev3dev2/_platform/pistorms.mpy
-rw-r--r-- root/root      3538 2018-10-28 04:18 ./usr/lib/micropython/ev3dev2/auto.mpy
-rw-r--r-- root/root      7126 2018-10-28 04:18 ./usr/lib/micropython/ev3dev2/button.mpy
drwxr-xr-x root/root         0 2018-10-28 04:18 ./usr/lib/micropython/ev3dev2/control/
-rw-r--r-- root/root      8614 2018-10-28 04:18 ./usr/lib/micropython/ev3dev2/control/GyroBalancer.mpy
-rw-r--r-- root/root        60 2018-10-28 04:18 ./usr/lib/micropython/ev3dev2/control/__init__.mpy
-rw-r--r-- root/root      1556 2018-10-28 04:18 ./usr/lib/micropython/ev3dev2/control/rc_tank.mpy
-rw-r--r-- root/root      6251 2018-10-28 04:18 ./usr/lib/micropython/ev3dev2/control/webserver.mpy
-rw-r--r-- root/root      8298 2018-10-28 04:18 ./usr/lib/micropython/ev3dev2/display.mpy
drwxr-xr-x root/root         0 2018-10-28 04:18 ./usr/lib/micropython/ev3dev2/fonts/
-rw-r--r-- root/root       902 2018-10-28 04:18 ./usr/lib/micropython/ev3dev2/fonts/__init__.mpy
-rw-r--r-- root/root      6416 2018-10-28 04:18 ./usr/lib/micropython/ev3dev2/led.mpy
-rw-r--r-- root/root     46563 2018-10-28 04:18 ./usr/lib/micropython/ev3dev2/motor.mpy
-rw-r--r-- root/root      2030 2018-10-28 04:18 ./usr/lib/micropython/ev3dev2/port.mpy
-rw-r--r-- root/root      2178 2018-10-28 04:18 ./usr/lib/micropython/ev3dev2/power.mpy
drwxr-xr-x root/root         0 2018-10-28 04:18 ./usr/lib/micropython/ev3dev2/sensor/
-rw-r--r-- root/root      7358 2018-10-28 04:18 ./usr/lib/micropython/ev3dev2/sensor/__init__.mpy
-rw-r--r-- root/root     16378 2018-10-28 04:18 ./usr/lib/micropython/ev3dev2/sensor/lego.mpy
-rw-r--r-- root/root      8880 2018-10-28 04:18 ./usr/lib/micropython/ev3dev2/sound.mpy
-rw-r--r-- root/root      6159 2018-10-28 04:18 ./usr/lib/micropython/ev3dev2/unit.mpy
-rw-r--r-- root/root        80 2018-10-28 04:18 ./usr/lib/micropython/ev3dev2/version.mpy
-rw-r--r-- root/root      1543 2018-10-28 04:18 ./usr/lib/micropython/ev3dev2/wheel.mpy
drwxr-xr-x root/root         0 2018-10-28 04:18 ./usr/share/
drwxr-xr-x root/root         0 2018-10-28 04:18 ./usr/share/doc/
drwxr-xr-x root/root         0 2018-10-28 04:18 ./usr/share/doc/micropython-ev3dev2/
-rw-r--r-- root/root       922 2018-10-28 04:18 ./usr/share/doc/micropython-ev3dev2/changelog.gz
-rw-r--r-- root/root      1597 2018-07-30 05:21 ./usr/share/doc/micropython-ev3dev2/copyright
```

---

Fixes #521 
