### PR TITLE
IR sensor "proximity" is object proximity, not distance to the remote

### DIFF
--- a/ev3dev2/sensor/lego.py
+++ b/ev3dev2/sensor/lego.py
@@ -775,8 +775,8 @@ class InfraredSensor(Sensor, ButtonBase):
     @property
     def proximity(self):
         """
-        A measurement of the distance between the sensor and the remote,
-        as a percentage. 100% is approximately 70cm/27in.
+        An estimate of the distance between the sensor and objects in front of
+        it, as a percentage. 100% is approximately 70cm/27in.
         """
         self._ensure_mode(self.MODE_IR_PROX)
         return self.value(0)


### PR DESCRIPTION
In light of the discussion in #518, I've fixed the `InfraredSensor.proximity` docstring to accurately reflect the sensor's behavior. I did not change the name of the property as it appears to match EV3-G's name and I feel that the current name is OK as long as the docstring isn't lying.

@ndward is this OK?

Fixes #518