### PR TITLE
Remove obsolete INPUT_AUTO and OUTPUT_AUTO

### DIFF
--- a/ev3dev2/__init__.py
+++ b/ev3dev2/__init__.py
@@ -45,10 +45,6 @@ import stat
 import errno
 from os.path import abspath
 
-INPUT_AUTO = ''
-OUTPUT_AUTO = ''
-
-
 def get_current_platform():
     """
     Look in /sys/class/board-info/ to determine the platform type.


### PR DESCRIPTION
These aren't in the right place to be used along with the others, and the behavior exists already by omitting the `address`-related parameter, so I don't see a reason for these to be here.