### PR TITLE
Expose ev3dev2.version.__version__ as ev3dev2.__version__

### DIFF
--- a/ev3dev2/__init__.py
+++ b/ev3dev2/__init__.py
@@ -37,6 +37,13 @@ def chain_exception(exception, cause):
     else:
         raise exception from cause
 
+try:
+    # if we are in a released build, there will be an auto-generated "version"
+    # module
+    from .version import __version__
+except ImportError:
+    __version__ = "<unknown>"
+
 import os
 import io
 import fnmatch


### PR DESCRIPTION
I don't think we advertise this anywhere, but nonetheless it's nice to have it available from the root module.