### PR TITLE
Missing rename namespace: ev3dev -> ev3dev2 for gyro

### DIFF
--- a/ev3dev2/control/GyroBalancer.py
+++ b/ev3dev2/control/GyroBalancer.py
@@ -35,10 +35,10 @@ import threading
 import math
 import signal
 from collections import deque
-from ev3dev.power import PowerSupply
-from ev3dev.motor import LargeMotor, OUTPUT_A, OUTPUT_D
-from ev3dev.sensor.lego import GyroSensor, TouchSensor
-from ev3dev.sound import Sound
+from ev3dev2.power import PowerSupply
+from ev3dev2.motor import LargeMotor, OUTPUT_A, OUTPUT_D
+from ev3dev2.sensor.lego import GyroSensor, TouchSensor
+from ev3dev2.sound import Sound
 from collections import OrderedDict
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
This file was missed in PR #412.

Without this change the [balanc3r robot demo drive code](https://github.com/ev3dev/ev3dev-lang-python-demo/blob/stretch/robots/BALANC3R/drive.py) will exit in error failing to load `ev3dev.power`.