### PR TITLE
Sound: fallback to regular case of 'note' if uppercase is not found

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+python-ev3dev2 (2.0.0~beta4) UNRELEASED; urgency=medium
+
+  [Daniel Walton]
+  * Sound: fallback to regular case of 'note' if uppercase is not found
+
+ -- Kaelin Laundry <wasabifan@outlook.com>  Sun, 24 Mar 2019 00:25:00 -0800
+
 python-ev3dev2 (2.0.0~beta3) stable; urgency=medium
 
   [Daniel Walton]

--- a/ev3dev2/sound.py
+++ b/ev3dev2/sound.py
@@ -237,9 +237,10 @@ class Sound(object):
         """
         self._validate_play_type(play_type)
         try:
-            freq = self._NOTE_FREQUENCIES[note.upper()]
+            freq = self._NOTE_FREQUENCIES.get(note.upper(), self._NOTE_FREQUENCIES[note])
         except KeyError:
             raise ValueError('invalid note (%s)' % note)
+
         if duration <= 0:
             raise ValueError('invalid duration (%s)' % duration)
         if not 0 < volume <= 100:
@@ -457,7 +458,8 @@ class Sound(object):
             Returns:
                 str: the arguments to be passed to the beep command
             """
-            freq = self._NOTE_FREQUENCIES[note.upper()]
+            freq = self._NOTE_FREQUENCIES.get(note.upper(), self._NOTE_FREQUENCIES[note])
+
             if '/' in value:
                 base, factor = value.split('/')
                 duration_ms = meas_duration_ms * self._NOTE_VALUES[base] / float(factor)


### PR DESCRIPTION
Fixes issues #594.  Tested via
```
#!/usr/bin/env python3

from ev3dev2.sound import Sound

sound = Sound()
sound.play_song((
    ('Db4', 'e3'),
))

# star wars
sound.play_song((
    ('D4', 'e3'),      # intro anacrouse
    ('D4', 'e3'),
    ('D4', 'e3'),
    ('G4', 'h'),       # meas 1
    ('D5', 'h'),
    ('C5', 'e3'),      # meas 2
    ('B4', 'e3'),
    ('A4', 'e3'),
    ('G5', 'h'),
    ('D5', 'q'),
    ('C5', 'e3'),      # meas 3
    ('B4', 'e3'),
    ('A4', 'e3'),
    ('G5', 'h'),
    ('D5', 'q'),
    ('C5', 'e3'),      # meas 4
    ('B4', 'e3'),
    ('C5', 'e3'),
    ('A4', 'h.'),
))
```
