### PR TITLE
Fix GyroAngle.reset()

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,9 @@ python-ev3dev2 (2.0.0~beta4) UNRELEASED; urgency=medium
   * Sound: fallback to regular case of 'note' if uppercase is not found
   * wait_until_not_moving should consider "running holding" as "moving"
 
+  [David Lechner]
+  * Fix and document ev3dev2.sensors.lego.GyroSensor.reset()
+
  -- Kaelin Laundry <wasabifan@outlook.com>  Sun, 24 Mar 2019 00:25:00 -0800
 
 python-ev3dev2 (2.0.0~beta3) stable; urgency=medium

--- a/ev3dev2/sensor/lego.py
+++ b/ev3dev2/sensor/lego.py
@@ -623,6 +623,15 @@ class GyroSensor(Sensor):
         return self.value(0)
 
     def reset(self):
+        """Resets the angle to 0.
+
+        Caveats:
+            - This function sets the sensor to `GYRO-ANG` mode if it is not
+              already in that mode.
+            - This function only resets the angle to 0, it does not fix drift.
+            - This function only works on EV3, it does not work on BrickPi,
+              PiStorms, or with any sensor multiplexors.
+        """
         self._ensure_mode(self.MODE_GYRO_ANG)
         # 17 comes from inspecting the .vix file of the Gyro sensor block in EV3-G
         self._direct = self.set_attr_raw(self._direct, 'direct', bytes(17,))

--- a/ev3dev2/sensor/lego.py
+++ b/ev3dev2/sensor/lego.py
@@ -624,7 +624,8 @@ class GyroSensor(Sensor):
 
     def reset(self):
         self._ensure_mode(self.MODE_GYRO_ANG)
-        self._direct = self.set_attr_raw(self._direct, 'direct', 17)
+        # 17 comes from inspecting the .vix file of the Gyro sensor block in EV3-G
+        self._direct = self.set_attr_raw(self._direct, 'direct', bytes(17,))
 
     def wait_until_angle_changed_by(self, delta, direction_sensitive=False):
         """

--- a/ev3dev2/sensor/lego.py
+++ b/ev3dev2/sensor/lego.py
@@ -626,13 +626,10 @@ class GyroSensor(Sensor):
         """Resets the angle to 0.
 
         Caveats:
-            - This function sets the sensor to `GYRO-ANG` mode if it is not
-              already in that mode.
             - This function only resets the angle to 0, it does not fix drift.
             - This function only works on EV3, it does not work on BrickPi,
               PiStorms, or with any sensor multiplexors.
         """
-        self._ensure_mode(self.MODE_GYRO_ANG)
         # 17 comes from inspecting the .vix file of the Gyro sensor block in EV3-G
         self._direct = self.set_attr_raw(self._direct, 'direct', bytes(17,))
 


### PR DESCRIPTION
`Sensor.set_attr_raw()` takes a bytes-like object for the `value` parameter.

Also add a comment about where the value comes from while we are at it.

Note: this requires a kernel driver fix before the reset will actually work See ev3dev/ev3dev#1236.

Suggested-by: @matskew 
Fixes: #510