### PR TITLE
Display() text-only implementation for micropython

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+OUT := build
+MPYCROSS := /usr/bin/mpy-cross
+MPYC_FLAGS := -v -v -mcache-lookup-bc
+PYS := $(shell find ./ev3dev2 -type f \( -iname "*.py" ! -iname "setup.py" \))
+MPYS := $(PYS:./%.py=${OUT}/%.mpy)
+vpath %.py .
+
+${OUT}/%.mpy: %.py
+	@mkdir -p $(dir $@)
+	${MPYCROSS} ${MPYC_FLAGS} -o $@ $<
+
+install: ${MPYS}
+	cp -R $(OUT)/* /usr/lib/micropython/

--- a/docs/micropython.md
+++ b/docs/micropython.md
@@ -12,8 +12,8 @@ Module                          Support status
 ==============================  =================
 `ev3dev2.button`                ️️✔️
 `ev3dev2.control` [1]_          ⚠️
-`ev3dev2.display`               ❌
-`ev3dev2.fonts` [2]_            ⚠️
+`ev3dev2.display` [2]_          ⚠️
+`ev3dev2.fonts`   [3]_          ❌
 `ev3dev2.led`                   ✔️
 `ev3dev2.motor`                 ✔️
 `ev3dev2.port`                  ✔️
@@ -25,7 +25,8 @@ Module                          Support status
 ==============================  =================
 
 .. [1] Untested/low-priority, but some of it might work.
-.. [2] It might work, but isn't useful without ``ev3dev2.display``.
+.. [2] Display() works for text only, using ANSI codes to the console LCD screen.
+.. [3] The fonts module is replaced with the ability to change the console font using the Display() class.
 ```
 
 ## Differences from standard Python (CPython)
@@ -36,10 +37,42 @@ See [the MicroPython differences page](http://docs.micropython.org/en/latest/gen
 
 You should modify the first line of your scripts to replace "python3" with "micropython":
 
-```
+```python
 #!/usr/bin/env micropython
 ```
 
 ### Running from the command line
 
 If you previously would have typed `python3 foo.py`, you should now type `micropython foo.py`.
+
+If you are running programs via an SSH shell, use the following command line to inform Brickman that your
+program needs control of the EV3:
+
+```shell
+brickrun -- ./program.py
+```
+
+### Displaying text on the EV3 LCD screen
+
+The EV3 LCD console supports ANSI codes to position the cursor, clear the screen, show text with different fonts,
+and use reverse (white text on black background, versus the default black text on white background). See the file
+`utils/display_fonts.py` to see the fonts supported with sample calls to the `ev3dev2.Display()` class.
+
+### Building and installing the latest EV3DEV2 module on your EV3
+
+In an SSH Terminal window with an EV3 with Internet access, run the following commands:
+(recall that the `sudo` password is `maker`)
+
+```shell
+git clone https://github.com/ev3dev/ev3dev-lang-python.git
+cd ev3dev-lang-python
+sudo make
+```
+
+To update the module, use the following commands:
+
+```shell
+cd ev3dev-lang-python
+git pull
+sudo make
+```

--- a/ev3dev2/display.py
+++ b/ev3dev2/display.py
@@ -75,6 +75,7 @@ if is_micropython():
                 y (int): Where to start the top of the text
                 color (bool): ``True`` for white, otherwise black
                 font (int): The size of the font [0..2]
+
             """
             pass
 
@@ -485,7 +486,7 @@ else:
 
             - If font is a string, it is the name of a font to be loaded.
             - If font is a Font object, returned from :meth:`ev3dev2.fonts.load`, then it is
-            used directly.  This is desirable for faster display times.
+              used directly.  This is desirable for faster display times.
 
             """
 
@@ -518,7 +519,7 @@ else:
 
             - If font is a string, it is the name of a font to be loaded.
             - If font is a Font object, returned from :meth:`ev3dev2.fonts.load`, then it is
-            used directly.  This is desirable for faster display times.
+              used directly.  This is desirable for faster display times.
 
             """
 

--- a/ev3dev2/display.py
+++ b/ev3dev2/display.py
@@ -23,420 +23,518 @@
 # THE SOFTWARE.
 # -----------------------------------------------------------------------------
 
-import sys
-
-if sys.version_info < (3,4):
-    raise SystemError('Must be using Python 3.4 or higher')
-
 import os
-import mmap
-import ctypes
-import logging
-from PIL import Image, ImageDraw
-from . import fonts
-from . import get_current_platform, library_load_warning_message
-from struct import pack
+from . import is_micropython
 
-log = logging.getLogger(__name__)
+if is_micropython():
 
-try:
-    # This is a linux-specific module.
-    # It is required by the Display class, but failure to import it may be
-    # safely ignored if one just needs to run API tests on Windows.
-    import fcntl
-except ImportError:
-    log.warning(library_load_warning_message("fcntl", "Display"))
+    class Display(object):
+        """
+        Object that represents the EV3 LCD display screen, which implements ANSI escape sequences
+        for cursor positioning, text color, etc.
+        """
+
+        def __init__(self, font="Lat15-TerminusBold24x12"):
+            self.set_font(font)
+            self.reset_screen()
+
+        def set_font(self, font):
+            """
+            Set the LCD console font
+            Parameter:
+                `font` (string): Font name, as found in /usr/share/consolefonts/
+           """
+            self._font = font
+            os.system("setfont %s" % (font))
+            self.reset_screen()
+
+        def set_cursor(self, on=False):
+            """
+            Use ANSI escape sequence to turn LCD screen cursor on or off
+            Parameter:
+                `on` (bool): ``True`` to turn on the screen cursor; default is ``False``
+            """
+            # use escape code to turn cursor on or off
+            print("\x1b[?25%s" % ('h' if on else 'l'), end='')
+
+        def update(self):
+            """
+            NOTE: Not implemented for micropython
+            """
+            pass
+
+        def text_pixels(self, text, clear_screen, x, y, text_color=False, font=None):
+            """
+            NOTE: Not implemented for micropython
+            Draw text on the screen
+
+            Parameters:
+                text (str): The text to draw
+                clear (bool): When ``True``, clear the screen first
+                x (int): Where to start the left side of the text
+                y (int): Where to start the top of the text
+                color (bool): ``True`` for white, otherwise black
+                font (int): The size of the font [0..2]
+            """
+            pass
+
+        def text_grid(self, text, clear_screen=False, x=1, y=1, text_color=False, font=None):
+            """
+            Display 'text' (string) starting at grid (x, y). Note that the grid location is 1-based (not 0-based).
+
+            Depending on the font, the EV3 LCD display can show text within 4 to 21 rows, and 11 to 44 columns.
+            The default font results in a grid that is 14 columns wide and 5 rows tall.
+
+            Parameters:
+                'text' (string): Text to display
+                `x` (int): LCD column position to start the text (1 = left column)
+                `y` (int): LCD row position to start the text (1 = top row); text will wrap when it reaches the right edge
+                `clear_screen` (bool): ``True`` to clear the screen before showing the text; default is ``False``
+                `text_color` (bool): ``True`` for white, otherwise black; default is ``False``
+                `font` (string): Font name, as found in /usr/share/consolefonts/
+            """
+            if font is not None and font != self._font:
+                self.set_font(font)
+
+            if text_color:
+                text = "\x1b[7m%s\x1b[m" % (text)
+
+            print("\x1b[%d;%dH%s" % (y, x, text), end='')
+
+        def image(self, image_file, clear, x, y):
+            """
+            NOTE: Not implemented for micropython
+            Draw an image on the screen.
+
+            Parameters:
+                image_file (ImageFile): the image
+                clear (bool): When ``True`` clear the screen first
+                x (int): Where to start the left side of the image
+                y (int): Where to start the top of the image
+            """
+            pass
+
+        def reset_screen(self):
+            """
+            Clear the screen using ANSI escape sequences
+            """
+            print("\x1b[2J\x1b[H", end='')
+            self.set_cursor(False)
+
+else:
+    import sys
+
+    if sys.version_info < (3,4):
+        raise SystemError('Must be using Python 3.4 or higher')
+
+    import mmap
+    import ctypes
+    import logging
+    from PIL import Image, ImageDraw
+    from . import fonts
+    from . import get_current_platform, library_load_warning_message
+    from struct import pack
+    
+    log = logging.getLogger(__name__)
+
+    try:
+        # This is a linux-specific module.
+        # It is required by the Display class, but failure to import it may be
+        # safely ignored if one just needs to run API tests on Windows.
+        import fcntl
+    except ImportError:
+        log.warning(library_load_warning_message("fcntl", "Display"))
 
 
-class FbMem(object):
+    class FbMem(object):
 
-    """The framebuffer memory object.
+        """The framebuffer memory object.
 
-    Made of:
-        - the framebuffer file descriptor
-        - the fix screen info struct
-        - the var screen info struct
-        - the mapped memory
-    """
+        Made of:
+            - the framebuffer file descriptor
+            - the fix screen info struct
+            - the var screen info struct
+            - the mapped memory
+        """
 
-    # ------------------------------------------------------------------
-    # The code is adapted from
-    # https://github.com/LinkCareServices/cairotft/blob/master/cairotft/linuxfb.py
-    #
-    # The original code came with the following license:
-    # ------------------------------------------------------------------
-    # Copyright (c) 2012 Kurichan
-    #
-    # This program is free software. It comes without any warranty, to
-    # the extent permitted by applicable law. You can redistribute it
-    # and/or modify it under the terms of the Do What The Fuck You Want
-    # To Public License, Version 2, as published by Sam Hocevar. See
-    # http://sam.zoy.org/wtfpl/COPYING for more details.
-    # ------------------------------------------------------------------
+        # ------------------------------------------------------------------
+        # The code is adapted from
+        # https://github.com/LinkCareServices/cairotft/blob/master/cairotft/linuxfb.py
+        #
+        # The original code came with the following license:
+        # ------------------------------------------------------------------
+        # Copyright (c) 2012 Kurichan
+        #
+        # This program is free software. It comes without any warranty, to
+        # the extent permitted by applicable law. You can redistribute it
+        # and/or modify it under the terms of the Do What The Fuck You Want
+        # To Public License, Version 2, as published by Sam Hocevar. See
+        # http://sam.zoy.org/wtfpl/COPYING for more details.
+        # ------------------------------------------------------------------
 
-    __slots__ = ('fid', 'fix_info', 'var_info', 'mmap')
+        __slots__ = ('fid', 'fix_info', 'var_info', 'mmap')
 
-    FBIOGET_VSCREENINFO = 0x4600
-    FBIOGET_FSCREENINFO = 0x4602
+        FBIOGET_VSCREENINFO = 0x4600
+        FBIOGET_FSCREENINFO = 0x4602
 
-    FB_VISUAL_MONO01 = 0
-    FB_VISUAL_MONO10 = 1
+        FB_VISUAL_MONO01 = 0
+        FB_VISUAL_MONO10 = 1
 
-    class FixScreenInfo(ctypes.Structure):
+        class FixScreenInfo(ctypes.Structure):
 
-        """The fb_fix_screeninfo from fb.h."""
-
-        _fields_ = [
-            ('id_name', ctypes.c_char * 16),
-            ('smem_start', ctypes.c_ulong),
-            ('smem_len', ctypes.c_uint32),
-            ('type', ctypes.c_uint32),
-            ('type_aux', ctypes.c_uint32),
-            ('visual', ctypes.c_uint32),
-            ('xpanstep', ctypes.c_uint16),
-            ('ypanstep', ctypes.c_uint16),
-            ('ywrapstep', ctypes.c_uint16),
-            ('line_length', ctypes.c_uint32),
-            ('mmio_start', ctypes.c_ulong),
-            ('mmio_len', ctypes.c_uint32),
-            ('accel', ctypes.c_uint32),
-            ('reserved', ctypes.c_uint16 * 3),
-        ]
-
-    class VarScreenInfo(ctypes.Structure):
-
-        class FbBitField(ctypes.Structure):
-
-            """The fb_bitfield struct from fb.h."""
+            """The fb_fix_screeninfo from fb.h."""
 
             _fields_ = [
-                ('offset', ctypes.c_uint32),
-                ('length', ctypes.c_uint32),
-                ('msb_right', ctypes.c_uint32),
+                ('id_name', ctypes.c_char * 16),
+                ('smem_start', ctypes.c_ulong),
+                ('smem_len', ctypes.c_uint32),
+                ('type', ctypes.c_uint32),
+                ('type_aux', ctypes.c_uint32),
+                ('visual', ctypes.c_uint32),
+                ('xpanstep', ctypes.c_uint16),
+                ('ypanstep', ctypes.c_uint16),
+                ('ywrapstep', ctypes.c_uint16),
+                ('line_length', ctypes.c_uint32),
+                ('mmio_start', ctypes.c_ulong),
+                ('mmio_len', ctypes.c_uint32),
+                ('accel', ctypes.c_uint32),
+                ('reserved', ctypes.c_uint16 * 3),
+            ]
+
+        class VarScreenInfo(ctypes.Structure):
+
+            class FbBitField(ctypes.Structure):
+
+                """The fb_bitfield struct from fb.h."""
+
+                _fields_ = [
+                    ('offset', ctypes.c_uint32),
+                    ('length', ctypes.c_uint32),
+                    ('msb_right', ctypes.c_uint32),
+                ]
+
+                def __str__(self):
+                    return "%s (offset %s, length %s, msg_right %s)" %\
+                        (self.__class__.__name__, self.offset, self.length, self.msb_right)
+
+            """The fb_var_screeninfo struct from fb.h."""
+
+            _fields_ = [
+                ('xres', ctypes.c_uint32),
+                ('yres', ctypes.c_uint32),
+                ('xres_virtual', ctypes.c_uint32),
+                ('yres_virtual', ctypes.c_uint32),
+                ('xoffset', ctypes.c_uint32),
+                ('yoffset', ctypes.c_uint32),
+
+                ('bits_per_pixel', ctypes.c_uint32),
+                ('grayscale', ctypes.c_uint32),
+
+                ('red', FbBitField),
+                ('green', FbBitField),
+                ('blue', FbBitField),
+                ('transp', FbBitField),
             ]
 
             def __str__(self):
-                return "%s (offset %s, length %s, msg_right %s)" %\
-                    (self.__class__.__name__, self.offset, self.length, self.msb_right)
+                return ("%sx%s at (%s,%s), bpp %s, grayscale %s, red %s, green %s, blue %s, transp %s" %
+                    (self.xres, self.yres, self.xoffset, self.yoffset, self.bits_per_pixel, self.grayscale,
+                    self.red, self.green, self.blue, self.transp))
 
-        """The fb_var_screeninfo struct from fb.h."""
+        def __init__(self, fbdev=None):
+            """Create the FbMem framebuffer memory object."""
+            fid = FbMem._open_fbdev(fbdev)
+            fix_info = FbMem._get_fix_info(fid)
+            fbmmap = FbMem._map_fb_memory(fid, fix_info)
+            self.fid = fid
+            self.fix_info = fix_info
+            self.var_info = FbMem._get_var_info(fid)
+            self.mmap = fbmmap
 
-        _fields_ = [
-            ('xres', ctypes.c_uint32),
-            ('yres', ctypes.c_uint32),
-            ('xres_virtual', ctypes.c_uint32),
-            ('yres_virtual', ctypes.c_uint32),
-            ('xoffset', ctypes.c_uint32),
-            ('yoffset', ctypes.c_uint32),
+        @staticmethod
+        def _open_fbdev(fbdev=None):
+            """Return the framebuffer file descriptor.
 
-            ('bits_per_pixel', ctypes.c_uint32),
-            ('grayscale', ctypes.c_uint32),
+            Try to use the FRAMEBUFFER
+            environment variable if fbdev is not given. Use '/dev/fb0' by
+            default.
+            """
+            dev = fbdev or os.getenv('FRAMEBUFFER', '/dev/fb0')
+            fbfid = os.open(dev, os.O_RDWR)
+            return fbfid
 
-            ('red', FbBitField),
-            ('green', FbBitField),
-            ('blue', FbBitField),
-            ('transp', FbBitField),
-        ]
+        @staticmethod
+        def _get_fix_info(fbfid):
+            """Return the fix screen info from the framebuffer file descriptor."""
+            fix_info = FbMem.FixScreenInfo()
+            fcntl.ioctl(fbfid, FbMem.FBIOGET_FSCREENINFO, fix_info)
+            return fix_info
+
+        @staticmethod
+        def _get_var_info(fbfid):
+            """Return the var screen info from the framebuffer file descriptor."""
+            var_info = FbMem.VarScreenInfo()
+            fcntl.ioctl(fbfid, FbMem.FBIOGET_VSCREENINFO, var_info)
+            return var_info
+
+        @staticmethod
+        def _map_fb_memory(fbfid, fix_info):
+            """Map the framebuffer memory."""
+            return mmap.mmap(
+                fbfid,
+                fix_info.smem_len,
+                mmap.MAP_SHARED,
+                mmap.PROT_READ | mmap.PROT_WRITE,
+                offset=0
+            )
+
+
+    class Display(FbMem):
+        """
+        A convenience wrapper for the FbMem class.
+        Provides drawing functions from the python imaging library (PIL).
+        """
+
+        GRID_COLUMNS = 22
+        GRID_COLUMN_PIXELS = 8
+        GRID_ROWS = 12
+        GRID_ROW_PIXELS = 10
+
+        def __init__(self, desc='Display'):
+            FbMem.__init__(self)
+
+            self.platform = get_current_platform()
+
+            if self.var_info.bits_per_pixel == 1:
+                im_type = "1"
+
+            elif self.platform == "ev3" and self.var_info.bits_per_pixel == 32:
+                im_type = "L"
+
+            elif self.var_info.bits_per_pixel == 16 or self.var_info.bits_per_pixel == 32:
+                im_type = "RGB"
+
+            else:
+                raise Exception("Not supported - platform %s with bits_per_pixel %s" %
+                    (self.platform, self.var_info.bits_per_pixel))
+
+            self._img = Image.new(
+                    im_type,
+                    (self.fix_info.line_length * 8 // self.var_info.bits_per_pixel, self.yres),
+                    "white")
+
+            self._draw = ImageDraw.Draw(self._img)
+            self.desc = desc
 
         def __str__(self):
-            return ("%sx%s at (%s,%s), bpp %s, grayscale %s, red %s, green %s, blue %s, transp %s" %
-                (self.xres, self.yres, self.xoffset, self.yoffset, self.bits_per_pixel, self.grayscale,
-                self.red, self.green, self.blue, self.transp))
+            return self.desc
 
-    def __init__(self, fbdev=None):
-        """Create the FbMem framebuffer memory object."""
-        fid = FbMem._open_fbdev(fbdev)
-        fix_info = FbMem._get_fix_info(fid)
-        fbmmap = FbMem._map_fb_memory(fid, fix_info)
-        self.fid = fid
-        self.fix_info = fix_info
-        self.var_info = FbMem._get_var_info(fid)
-        self.mmap = fbmmap
+        @property
+        def xres(self):
+            """
+            Horizontal screen resolution
+            """
+            return self.var_info.xres
 
-    @staticmethod
-    def _open_fbdev(fbdev=None):
-        """Return the framebuffer file descriptor.
+        @property
+        def yres(self):
+            """
+            Vertical screen resolution
+            """
+            return self.var_info.yres
 
-        Try to use the FRAMEBUFFER
-        environment variable if fbdev is not given. Use '/dev/fb0' by
-        default.
-        """
-        dev = fbdev or os.getenv('FRAMEBUFFER', '/dev/fb0')
-        fbfid = os.open(dev, os.O_RDWR)
-        return fbfid
+        @property
+        def shape(self):
+            """
+            Dimensions of the screen.
+            """
+            return (self.xres, self.yres)
 
-    @staticmethod
-    def _get_fix_info(fbfid):
-        """Return the fix screen info from the framebuffer file descriptor."""
-        fix_info = FbMem.FixScreenInfo()
-        fcntl.ioctl(fbfid, FbMem.FBIOGET_FSCREENINFO, fix_info)
-        return fix_info
+        @property
+        def draw(self):
+            """
+            Returns a handle to PIL.ImageDraw.Draw class associated with the screen.
 
-    @staticmethod
-    def _get_var_info(fbfid):
-        """Return the var screen info from the framebuffer file descriptor."""
-        var_info = FbMem.VarScreenInfo()
-        fcntl.ioctl(fbfid, FbMem.FBIOGET_VSCREENINFO, var_info)
-        return var_info
+            Example::
 
-    @staticmethod
-    def _map_fb_memory(fbfid, fix_info):
-        """Map the framebuffer memory."""
-        return mmap.mmap(
-            fbfid,
-            fix_info.smem_len,
-            mmap.MAP_SHARED,
-            mmap.PROT_READ | mmap.PROT_WRITE,
-            offset=0
-        )
+                screen.draw.rectangle((10,10,60,20), fill='black')
+            """
+            return self._draw
 
+        @property
+        def image(self):
+            """
+            Returns a handle to PIL.Image class that is backing the screen. This can
+            be accessed for blitting images to the screen.
 
-class Display(FbMem):
-    """
-    A convenience wrapper for the FbMem class.
-    Provides drawing functions from the python imaging library (PIL).
-    """
+            Example::
 
-    GRID_COLUMNS = 22
-    GRID_COLUMN_PIXELS = 8
-    GRID_ROWS = 12
-    GRID_ROW_PIXELS = 10
+                screen.image.paste(picture, (0, 0))
+            """
+            return self._img
 
-    def __init__(self, desc='Display'):
-        FbMem.__init__(self)
+        def clear(self):
+            """
+            Clears the screen
+            """
+            self._draw.rectangle(((0, 0), self.shape), fill="white")
 
-        self.platform = get_current_platform()
+        def _color565(self, r, g, b):
+            """Convert red, green, blue components to a 16-bit 565 RGB value. Components
+            should be values 0 to 255.
+            """
+            return (((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3))
 
-        if self.var_info.bits_per_pixel == 1:
-            im_type = "1"
+        def _img_to_rgb565_bytes(self):
+            pixels = [self._color565(r, g, b) for (r, g, b) in self._img.getdata()]
+            return pack('H' * len(pixels), *pixels)
 
-        elif self.platform == "ev3" and self.var_info.bits_per_pixel == 32:
-            im_type = "L"
+        def update(self):
+            """
+            Applies pending changes to the screen.
+            Nothing will be drawn on the screen until this function is called.
+            """
+            if self.var_info.bits_per_pixel == 1:
+                b = self._img.tobytes("raw", "1;R")
+                self.mmap[:len(b)] = b
 
-        elif self.var_info.bits_per_pixel == 16 or self.var_info.bits_per_pixel == 32:
-            im_type = "RGB"
+            elif self.var_info.bits_per_pixel == 16:
+                self.mmap[:] = self._img_to_rgb565_bytes()
 
-        else:
-            raise Exception("Not supported - platform %s with bits_per_pixel %s" %
-                (self.platform, self.var_info.bits_per_pixel))
+            elif self.var_info.bits_per_pixel == 32:
+                self.mmap[:] = self._img.convert("RGB").tobytes("raw", "XRGB")
 
-        self._img = Image.new(
-                im_type,
-                (self.fix_info.line_length * 8 // self.var_info.bits_per_pixel, self.yres),
-                "white")
+            else:
+                raise Exception("Not supported - platform %s with bits_per_pixel %s" %
+                    (self.platform, self.var_info.bits_per_pixel))
 
-        self._draw = ImageDraw.Draw(self._img)
-        self.desc = desc
+        def image_filename(self, filename, clear_screen=True, x1=0, y1=0, x2=None, y2=None):
 
-    def __str__(self):
-        return self.desc
+            if clear_screen:
+                self.clear()
 
-    @property
-    def xres(self):
-        """
-        Horizontal screen resolution
-        """
-        return self.var_info.xres
+            filename_im = Image.open(filename)
 
-    @property
-    def yres(self):
-        """
-        Vertical screen resolution
-        """
-        return self.var_info.yres
+            if x2 is not None and y2 is not None:
+                return self._img.paste(filename_im, (x1, y1, x2, y2))
+            else:
+                return self._img.paste(filename_im, (x1, y1))
 
-    @property
-    def shape(self):
-        """
-        Dimensions of the screen.
-        """
-        return (self.xres, self.yres)
+        def line(self, clear_screen=True, x1=10, y1=10, x2=50, y2=50, line_color='black', width=1):
+            """
+            Draw a line from (x1, y1) to (x2, y2)
+            """
 
-    @property
-    def draw(self):
-        """
-        Returns a handle to PIL.ImageDraw.Draw class associated with the screen.
+            if clear_screen:
+                self.clear()
 
-        Example::
+            return self.draw.line((x1, y1, x2, y2), fill=line_color, width=width)
 
-            screen.draw.rectangle((10,10,60,20), fill='black')
-        """
-        return self._draw
+        def circle(self, clear_screen=True, x=50, y=50, radius=40, fill_color='black', outline_color='black'):
+            """
+            Draw a circle of 'radius' centered at (x, y)
+            """
 
-    @property
-    def image(self):
-        """
-        Returns a handle to PIL.Image class that is backing the screen. This can
-        be accessed for blitting images to the screen.
+            if clear_screen:
+                self.clear()
 
-        Example::
+            x1 = x - radius
+            y1 = y - radius
+            x2 = x + radius
+            y2 = y + radius
 
-            screen.image.paste(picture, (0, 0))
-        """
-        return self._img
+            return self.draw.ellipse((x1, y1, x2, y2), fill=fill_color, outline=outline_color)
 
-    def clear(self):
-        """
-        Clears the screen
-        """
-        self._draw.rectangle(((0, 0), self.shape), fill="white")
+        def rectangle(self, clear_screen=True, x1=10, y1=10, x2=80, y2=40, fill_color='black', outline_color='black'):
+            """
+            Draw a rectangle where the top left corner is at (x1, y1) and the
+            bottom right corner is at (x2, y2)
+            """
 
-    def _color565(self, r, g, b):
-        """Convert red, green, blue components to a 16-bit 565 RGB value. Components
-        should be values 0 to 255.
-        """
-        return (((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3))
+            if clear_screen:
+                self.clear()
 
-    def _img_to_rgb565_bytes(self):
-        pixels = [self._color565(r, g, b) for (r, g, b) in self._img.getdata()]
-        return pack('H' * len(pixels), *pixels)
+            return self.draw.rectangle((x1, y1, x2, y2), fill=fill_color, outline=outline_color)
 
-    def update(self):
-        """
-        Applies pending changes to the screen.
-        Nothing will be drawn on the screen until this function is called.
-        """
-        if self.var_info.bits_per_pixel == 1:
-            b = self._img.tobytes("raw", "1;R")
-            self.mmap[:len(b)] = b
+        def point(self, clear_screen=True, x=10, y=10, point_color='black'):
+            """
+            Draw a single pixel at (x, y)
+            """
 
-        elif self.var_info.bits_per_pixel == 16:
-            self.mmap[:] = self._img_to_rgb565_bytes()
+            if clear_screen:
+                self.clear()
 
-        elif self.var_info.bits_per_pixel == 32:
-            self.mmap[:] = self._img.convert("RGB").tobytes("raw", "XRGB")
+            return self.draw.point((x, y), fill=point_color)
 
-        else:
-            raise Exception("Not supported - platform %s with bits_per_pixel %s" %
-                (self.platform, self.var_info.bits_per_pixel))
+        def text_pixels(self, text, clear_screen=True, x=0, y=0, text_color='black', font=None):
+            """
+            Display `text` starting at pixel (x, y).
 
-    def image_filename(self, filename, clear_screen=True, x1=0, y1=0, x2=None, y2=None):
+            The EV3 display is 178x128 pixels
 
-        if clear_screen:
+            - (0, 0) would be the top left corner of the display
+            - (89, 64) would be right in the middle of the display
+
+            'text_color' : PIL says it supports "common HTML color names". There
+            are 140 HTML color names listed here that are supported by all modern
+            browsers. This is probably a good list to start with.
+            https://www.w3schools.com/colors/colors_names.asp
+
+            'font' : can be any font displayed here
+                http://ev3dev-lang.readthedocs.io/projects/python-ev3dev/en/ev3dev-stretch/display.html#bitmap-fonts
+
+            - If font is a string, it is the name of a font to be loaded.
+            - If font is a Font object, returned from :meth:`ev3dev2.fonts.load`, then it is
+            used directly.  This is desirable for faster display times.
+
+            """
+
+            if clear_screen:
+                self.clear()
+
+            if font is not None:
+                if isinstance(font, str):
+                    assert font in fonts.available(), "%s is an invalid font" % font
+                    font = fonts.load(font)
+                return self.draw.text((x, y), text, fill=text_color, font=font)
+            else:
+                return self.draw.text((x, y), text, fill=text_color)
+
+        def text_grid(self, text, clear_screen=True, x=0, y=0, text_color='black', font=None):
+            """
+            Display 'text' starting at grid (x, y)
+
+            The EV3 display can be broken down in a grid that is 22 columns wide
+            and 12 rows tall. Each column is 8 pixels wide and each row is 10
+            pixels tall.
+
+            'text_color' : PIL says it supports "common HTML color names". There
+            are 140 HTML color names listed here that are supported by all modern
+            browsers. This is probably a good list to start with.
+            https://www.w3schools.com/colors/colors_names.asp
+
+            'font' : can be any font displayed here
+                http://ev3dev-lang.readthedocs.io/projects/python-ev3dev/en/ev3dev-stretch/display.html#bitmap-fonts
+
+            - If font is a string, it is the name of a font to be loaded.
+            - If font is a Font object, returned from :meth:`ev3dev2.fonts.load`, then it is
+            used directly.  This is desirable for faster display times.
+
+            """
+
+            assert 0 <= x < Display.GRID_COLUMNS,\
+                "grid columns must be between 0 and %d, %d was requested" %\
+                ((Display.GRID_COLUMNS - 1, x))
+
+            assert 0 <= y < Display.GRID_ROWS,\
+                "grid rows must be between 0 and %d, %d was requested" %\
+                ((Display.GRID_ROWS - 1), y)
+
+            return self.text_pixels(text, clear_screen,
+                                    x * Display.GRID_COLUMN_PIXELS,
+                                    y * Display.GRID_ROW_PIXELS,
+                                    text_color, font)
+
+        def reset_screen(self):
             self.clear()
-
-        filename_im = Image.open(filename)
-
-        if x2 is not None and y2 is not None:
-            return self._img.paste(filename_im, (x1, y1, x2, y2))
-        else:
-            return self._img.paste(filename_im, (x1, y1))
-
-    def line(self, clear_screen=True, x1=10, y1=10, x2=50, y2=50, line_color='black', width=1):
-        """
-        Draw a line from (x1, y1) to (x2, y2)
-        """
-
-        if clear_screen:
-            self.clear()
-
-        return self.draw.line((x1, y1, x2, y2), fill=line_color, width=width)
-
-    def circle(self, clear_screen=True, x=50, y=50, radius=40, fill_color='black', outline_color='black'):
-        """
-        Draw a circle of 'radius' centered at (x, y)
-        """
-
-        if clear_screen:
-            self.clear()
-
-        x1 = x - radius
-        y1 = y - radius
-        x2 = x + radius
-        y2 = y + radius
-
-        return self.draw.ellipse((x1, y1, x2, y2), fill=fill_color, outline=outline_color)
-
-    def rectangle(self, clear_screen=True, x1=10, y1=10, x2=80, y2=40, fill_color='black', outline_color='black'):
-        """
-        Draw a rectangle where the top left corner is at (x1, y1) and the
-        bottom right corner is at (x2, y2)
-        """
-
-        if clear_screen:
-            self.clear()
-
-        return self.draw.rectangle((x1, y1, x2, y2), fill=fill_color, outline=outline_color)
-
-    def point(self, clear_screen=True, x=10, y=10, point_color='black'):
-        """
-        Draw a single pixel at (x, y)
-        """
-
-        if clear_screen:
-            self.clear()
-
-        return self.draw.point((x, y), fill=point_color)
-
-    def text_pixels(self, text, clear_screen=True, x=0, y=0, text_color='black', font=None):
-        """
-        Display `text` starting at pixel (x, y).
-
-        The EV3 display is 178x128 pixels
-
-        - (0, 0) would be the top left corner of the display
-        - (89, 64) would be right in the middle of the display
-
-        'text_color' : PIL says it supports "common HTML color names". There
-        are 140 HTML color names listed here that are supported by all modern
-        browsers. This is probably a good list to start with.
-        https://www.w3schools.com/colors/colors_names.asp
-
-        'font' : can be any font displayed here
-            http://ev3dev-lang.readthedocs.io/projects/python-ev3dev/en/ev3dev-stretch/display.html#bitmap-fonts
-
-        - If font is a string, it is the name of a font to be loaded.
-        - If font is a Font object, returned from :meth:`ev3dev2.fonts.load`, then it is
-          used directly.  This is desirable for faster display times.
-
-        """
-
-        if clear_screen:
-            self.clear()
-
-        if font is not None:
-            if isinstance(font, str):
-                assert font in fonts.available(), "%s is an invalid font" % font
-                font = fonts.load(font)
-            return self.draw.text((x, y), text, fill=text_color, font=font)
-        else:
-            return self.draw.text((x, y), text, fill=text_color)
-
-    def text_grid(self, text, clear_screen=True, x=0, y=0, text_color='black', font=None):
-        """
-        Display 'text' starting at grid (x, y)
-
-        The EV3 display can be broken down in a grid that is 22 columns wide
-        and 12 rows tall. Each column is 8 pixels wide and each row is 10
-        pixels tall.
-
-        'text_color' : PIL says it supports "common HTML color names". There
-        are 140 HTML color names listed here that are supported by all modern
-        browsers. This is probably a good list to start with.
-        https://www.w3schools.com/colors/colors_names.asp
-
-        'font' : can be any font displayed here
-            http://ev3dev-lang.readthedocs.io/projects/python-ev3dev/en/ev3dev-stretch/display.html#bitmap-fonts
-
-        - If font is a string, it is the name of a font to be loaded.
-        - If font is a Font object, returned from :meth:`ev3dev2.fonts.load`, then it is
-          used directly.  This is desirable for faster display times.
-
-        """
-
-        assert 0 <= x < Display.GRID_COLUMNS,\
-            "grid columns must be between 0 and %d, %d was requested" %\
-            ((Display.GRID_COLUMNS - 1, x))
-
-        assert 0 <= y < Display.GRID_ROWS,\
-            "grid rows must be between 0 and %d, %d was requested" %\
-            ((Display.GRID_ROWS - 1), y)
-
-        return self.text_pixels(text, clear_screen,
-                                x * Display.GRID_COLUMN_PIXELS,
-                                y * Display.GRID_ROW_PIXELS,
-                                text_color, font)
-
-    def reset_screen(self):
-        self.clear()
-        self.update()
+            self.update()

--- a/utils/display_fonts.py
+++ b/utils/display_fonts.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env micropython
+from time import sleep
+from sys import stderr, stdin
+from os import listdir
+from ev3dev2.display import Display
+
+"""
+Used to iterate over the system console fonts (in /usr/share/consolefonts) and calculate the max row/col
+position by moving the cursor at max-row/max-column and asking the LCD for the actual cursor position
+where it ends up (the EV3 LCD screen driver prevents the cursor from positioning off-screen).
+
+The font specification consists of three parameters - codeset, font face and font size. The codeset specifies
+what characters will be supported by the font. The font face determines the general look of the font. Each
+font face is available in certain possible sizes.
+
+For Codeset clarity, see https://www.systutorials.com/docs/linux/man/5-console-setup/#lbAP
+
+    Lat15: Covers entirely ISO-8859-1, ISO-8859-9 and ISO-8859-15. Suitable for the so called Latin1 and
+    Latin5 languages - Afar, Afrikaans, Albanian, Aragonese, Asturian, Aymara, Basque, Bislama, Breton, Catalan,
+    Chamorro, Danish, Dutch, English, Estonian, Faroese, Fijian, Finnish, French, Frisian, Friulian, Galician,
+    German, Hiri Motu, Icelandic, Ido, Indonesian, Interlingua, Interlingue, Italian, Low Saxon, Lule Sami,
+    Luxembourgish, Malagasy, Manx Gaelic, Norwegian Bokmal, Norwegian Nynorsk, Occitan, Oromo or Galla,
+    Portuguese, Rhaeto-Romance (Romansch), Scots Gaelic, Somali, South Sami, Spanish, Swahili, Swedish, Tswana,
+    Turkish, Volapuk, Votic, Walloon, Xhosa, Yapese and Zulu. Completely covered by the following font faces:
+    Fixed (all sizes), Terminus (all sizes), TerminusBold (all sizes), TerminusBoldVGA (all sizes),
+    VGA (sizes 8x16 and 16x32).
+
+    Lat2: Covers entirely ISO-8859-2. The Euro sign and the Romanian letters with comma below are also supported.
+    Suitable for the so called Latin2 languages - Bosnian, Croatian, Czech, Hungarian, Polish, Romanian,
+    Slovak, Slovenian and Sorbian (lower and upper). Completely covered by the following font faces:
+    Fixed (all sizes), Terminus (all sizes), TerminusBold (all sizes), TerminusBoldVGA (all sizes),
+    VGA (sizes 8x16 and 16x32).
+
+    Lat38: Covers entirely ISO-8859-3 and ISO-8859-14. Suitable for Chichewa Esperanto, Irish, Maltese and Welsh.
+    Completely covered by the following font faces: Fixed (all sizes) and VGA (sizes 8x16 and 16x32).
+
+    Lat7: Covers entirely ISO-8859-13. Suitable for Lithuanian, Latvian, Maori and Marshallese.
+    Completely covered by the following font faces: Fixed (all sizes), Terminus (all sizes),
+    TerminusBold (all sizes), TerminusBoldVGA (all sizes), VGA (sizes 8x16 and 16x32).
+"""
+
+
+def calc_fonts():
+    """
+    Iterate through all the Latin "1 & 5" fonts, and use ANSI escape sequences to see how many rows/columns
+    the EV3 LCD screen can accommodate for each font
+    """
+    lcd = Display()
+
+    files = [f for f in listdir("/usr/share/consolefonts/") if f.startswith("Lat15") and f.endswith(".psf.gz")]
+    files.sort()
+    for font in files:
+        lcd.set_font(font)
+
+        # position cursor at 50, 50, and ask the console to report its actual cursor position
+        lcd.text_grid("\x1b[6n", False, 50, 50)
+        lcd.text_grid(font + " ", False, 1, 1, True)
+
+        # now, read the console response of the actual cursor position, in the form of esc[rr;ccR
+        # requires pressing the center button on the EV3 for each read
+        dims = ''
+        while True:
+            ch = stdin.read(1)
+            if ch == '\x1b' or ch == '[' or ch == '\r' or ch == '\n':
+                continue
+            if ch == 'R':
+                break
+            dims += str(ch)
+        (rows, cols) = dims.split(";")
+        print("(%s, %s, \"%s\")," % (rows, cols, font), file=stderr)
+        sleep(.5)
+
+
+def test_fonts():
+    """
+    Iterate over the known Latin "1 & 5" fonts and display each on the EV3 LCD panel.
+    Note: Terminus fonts are "thinner"; TerminusBold and VGA offer more contrast on the LCD screen
+    and are thus more readable; the TomThumb font is waaaaay too small to read!
+    """
+    lcd = Display()
+
+    # Create a list of tuples with calulated rows, columns, font filename
+    fonts = [
+        ( 4, 11, "Lat15-Terminus32x16.psf.gz"),
+        ( 4, 11, "Lat15-TerminusBold32x16.psf.gz"),
+        ( 4, 11, "Lat15-VGA28x16.psf.gz"),
+        ( 4, 11, "Lat15-VGA32x16.psf.gz"),
+        ( 4, 12, "Lat15-Terminus28x14.psf.gz"),
+        ( 4, 12, "Lat15-TerminusBold28x14.psf.gz"),
+        ( 5, 14, "Lat15-Terminus24x12.psf.gz"),
+        ( 5, 14, "Lat15-TerminusBold24x12.psf.gz"),
+        ( 5, 16, "Lat15-Terminus22x11.psf.gz"),
+        ( 5, 16, "Lat15-TerminusBold22x11.psf.gz"),
+        ( 6, 17, "Lat15-Terminus20x10.psf.gz"),
+        ( 6, 17, "Lat15-TerminusBold20x10.psf.gz"),
+        ( 7, 22, "Lat15-Fixed18.psf.gz"),
+        ( 8, 22, "Lat15-Fixed15.psf.gz"),
+        ( 8, 22, "Lat15-Fixed16.psf.gz"),
+        ( 8, 22, "Lat15-Terminus16.psf.gz"),
+        ( 8, 22, "Lat15-TerminusBold16.psf.gz"),
+        ( 8, 22, "Lat15-TerminusBoldVGA16.psf.gz"),
+        ( 8, 22, "Lat15-VGA16.psf.gz"),
+        ( 9, 22, "Lat15-Fixed13.psf.gz"),
+        ( 9, 22, "Lat15-Fixed14.psf.gz"),
+        ( 9, 22, "Lat15-Terminus14.psf.gz"),
+        ( 9, 22, "Lat15-TerminusBold14.psf.gz"),
+        ( 9, 22, "Lat15-TerminusBoldVGA14.psf.gz"),
+        ( 9, 22, "Lat15-VGA14.psf.gz"),
+        (10, 29, "Lat15-Terminus12x6.psf.gz"),
+        (16, 22, "Lat15-VGA8.psf.gz"),
+        (21, 44, "Lat15-TomThumb4x6.psf.gz")
+    ]
+   
+    # Paint the screen full of numbers that represent the column number, reversing the even rows
+    for rows, cols, font in fonts:
+        print(rows, cols, font, file=stderr)
+        lcd.set_font(font)
+        for row in range(1, rows+1):
+            for col in range(1, cols+1):
+                lcd.text_grid("%d" % (col % 10), False, col, row, (row % 2 == 0))
+        lcd.text_grid(font.split(".")[0] + " ", False, 1, 1, True)
+        sleep(.5)
+
+
+# calc_fonts()
+test_fonts()
+
+sleep(5)


### PR DESCRIPTION
For issue #635 Micropython support for Display

This is a text-only implementation using the EV3 LCD console ANSI code support to position the cursor, clear the screen, show text with different fonts, and use reverse (white text on black background, versus the default black text on white background). See the file utils/display_fonts.py to see the fonts supported with sample calls to the ev3dev2.Display() class.

Also included a Makefile so folks can git clone, build and install the latest ev3dev2 modules to the /usr/lib/micropython directory on their EV3.