### PR TITLE
LED animation fix duration None

### DIFF
--- a/ev3dev2/led.py
+++ b/ev3dev2/led.py
@@ -415,7 +415,7 @@ class Leds(object):
                     self.set_color(group1, color2)
                     self.set_color(group2, color1)
 
-                if self.animate_thread_stop or (duration is not None and stopwatch.value_ms >= duration_ms):
+                if self.animate_thread_stop or (duration_ms is not None and stopwatch.value_ms >= duration_ms):
                     break
 
                 even = not even

--- a/ev3dev2/led.py
+++ b/ev3dev2/led.py
@@ -403,8 +403,7 @@ class Leds(object):
         def _animate_police_lights():
             self.all_off()
             even = True
-            if duration is not None:
-                duration_ms = duration * 1000
+            duration_ms = duration * 1000 if duration is not None else None
             stopwatch = StopWatch()
             stopwatch.start()
 

--- a/ev3dev2/led.py
+++ b/ev3dev2/led.py
@@ -401,7 +401,8 @@ class Leds(object):
         def _animate_police_lights():
             self.all_off()
             even = True
-            duration_ms = duration * 1000
+            if duration != None:
+                duration_ms = duration * 1000
             stopwatch = StopWatch()
             stopwatch.start()
 
@@ -413,7 +414,7 @@ class Leds(object):
                     self.set_color(group1, color2)
                     self.set_color(group2, color1)
 
-                if self.animate_thread_stop or stopwatch.value_ms >= duration_ms:
+                if self.animate_thread_stop or (duration != None and stopwatch.value_ms >= duration_ms):
                     break
 
                 even = not even

--- a/ev3dev2/led.py
+++ b/ev3dev2/led.py
@@ -403,7 +403,7 @@ class Leds(object):
         def _animate_police_lights():
             self.all_off()
             even = True
-            if duration != None:
+            if duration is not None:
                 duration_ms = duration * 1000
             stopwatch = StopWatch()
             stopwatch.start()
@@ -416,7 +416,7 @@ class Leds(object):
                     self.set_color(group1, color2)
                     self.set_color(group2, color1)
 
-                if self.animate_thread_stop or (duration != None and stopwatch.value_ms >= duration_ms):
+                if self.animate_thread_stop or (duration is not None and stopwatch.value_ms >= duration_ms):
                     break
 
                 even = not even

--- a/ev3dev2/led.py
+++ b/ev3dev2/led.py
@@ -354,6 +354,8 @@ class Leds(object):
         if not self.leds:
             return
 
+        self.animate_stop()
+
         for led in self.leds.values():
             led.brightness = 0
 


### PR DESCRIPTION
- allow passing `duration=None` to `animate_police_lights` to animate forever, as stated in docs
- add animations reset to `all_off`, as without it the leds light up on the next animation cycle