### PR TITLE
Add seconds and elapsed checks to stopwatch

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+python-ev3dev2 (2.0.0) UNRELEASED; urgency=medium
+
+  [Kaelin Laundry]
+  * Add "value_secs" and "is_elapsed_*" methods to StopWatch
+  * Rename "value_hms" to "hms_str". New "value_hms" returns original tuple.
+
+ -- UNRELEASED
+
 python-ev3dev2 (2.0.0~beta5) stretch; urgency=medium
 
   [Brady Merkel]

--- a/ev3dev2/stopwatch.py
+++ b/ev3dev2/stopwatch.py
@@ -25,7 +25,7 @@ class StopWatch(object):
         Initializes the StopWatch but does not start it.
 
         desc:
-            A string description to pring when stringifying.
+            A string description to print when stringifying.
         """
         self.desc = desc
         self._value = 0

--- a/ev3dev2/stopwatch.py
+++ b/ev3dev2/stopwatch.py
@@ -15,6 +15,13 @@ def get_ticks_ms():
     else:
         return int(dt.datetime.timestamp(dt.datetime.now()) * 1000)
 
+class StopWatchAlreadyStartedException(Exception):
+    """
+    Exception raised when start() is called on a StopWatch which was already start()ed and not yet
+    stopped.
+    """
+    pass
+
 class StopWatch(object):
     """
     A timer class which lets you start timing and then check the amount of time
@@ -38,7 +45,12 @@ class StopWatch(object):
     def start(self):
         """
         Starts the timer. If the timer is already running, resets it.
+
+        Raises a :py:class:`ev3dev2.stopwatch.StopWatchAlreadyStartedException` if already started.
         """
+        if self.is_started:
+            raise StopWatchAlreadyStartedException()
+
         self._stopped_total_time = None
         self._start_time = get_ticks_ms()
 
@@ -54,10 +66,16 @@ class StopWatch(object):
 
     def reset(self):
         """
-        Resets the timer, and starts it again.
+        Resets the timer and leaves it stopped.
         """
         self._start_time = None
         self._stopped_total_time = None
+    
+    def restart(self):
+        """
+        Resets and then starts the timer.
+        """
+        self.reset()
         self.start()
     
     @property

--- a/ev3dev2/stopwatch.py
+++ b/ev3dev2/stopwatch.py
@@ -9,76 +9,114 @@ if is_micropython():
 else:
     import datetime as dt
 
-
 def get_ticks_ms():
     if is_micropython():
         return utime.ticks_ms()
     else:
         return int(dt.datetime.timestamp(dt.datetime.now()) * 1000)
 
-
 class StopWatch(object):
-
+    """
+    A timer class which lets you start timing and then check the amount of time
+    elapsed.
+    """
     def __init__(self, desc=None):
+        """
+        Initializes the StopWatch but does not start it.
+
+        desc:
+            A string description to pring when stringifying.
+        """
         self.desc = desc
         self._value = 0
-        self.start_time = None
-        self.prev_update_time = None
+        self._start_time = None
+        self._stopped_total_time = None
 
     def __str__(self):
-        if self.desc is not None:
-            return self.desc
-        else:
-            return self.__class__.__name__
+        name = self.desc if self.desc is not None else self.__class__.__name__
+        return "{}: {}".format(name, self.hms_str)
 
     def start(self):
-        assert self.start_time is None, "%s is already running" % self
-        self.start_time = get_ticks_ms()
-
-    def update(self):
-
-        if self.start_time is None:
-            return
-
-        current_time = get_ticks_ms()
-
-        if self.prev_update_time is None:
-            delta = current_time - self.start_time
-        else:
-            delta = current_time - self.prev_update_time
-
-        self._value += delta
-        self.prev_update_time = current_time
+        """
+        Starts the timer. If the timer is already running, resets it.
+        """
+        self._stopped_total_time = None
+        self._start_time = get_ticks_ms()
 
     def stop(self):
-
-        if self.start_time is None:
+        """
+        Stops the timer. The time value of this Stopwatch is paused and will not continue increasing.
+        """
+        if self._start_time is None:
             return
 
-        self.update()
-        self.start_time = None
-        self.prev_update_time = None
+        self._stopped_total_time = get_ticks_ms() - self._start_time
+        self._start_time = None
 
     def reset(self):
-        self.stop()
-        self._value = 0
+        """
+        Resets the timer, and starts it again.
+        """
+        self._start_time = None
+        self._stopped_total_time = None
+        self.start()
+    
+    @property
+    def is_started(self):
+        """
+        True if the StopWatch has been started but not stoped (i.e., it's currently running), false otherwise.
+        """
+        return self._start_time is not None
 
     @property
     def value_ms(self):
         """
         Returns the value of the stopwatch in milliseconds
         """
-        self.update()
-        return self._value
+        if self._stopped_total_time is not None:
+            return self._stopped_total_time
+
+        return get_ticks_ms() - self._start_time if self._start_time is not None else 0
+
+    @property
+    def value_secs(self):
+        """
+        Returns the value of the stopwatch in seconds
+        """
+        return self.value_ms / 1000
 
     @property
     def value_hms(self):
         """
-        Returns the value of the stopwatch in HH:MM:SS.msec format
+        Returns this StopWatch's elapsed time as a tuple
+        ``(hours, minutes, seconds, milliseconds)``.
         """
-        self.update()
-        (hours, x) = divmod(int(self._value), 3600000)
+        (hours, x) = divmod(int(self.value_ms), 3600000)
         (mins, x) = divmod(x, 60000)
         (secs, x) = divmod(x, 1000)
+        return hours, mins, secs, x
 
-        return '%02d:%02d:%02d.%03d' % (hours, mins, secs, x)
+    @property
+    def hms_str(self):
+        """
+        Returns the stringified value of the stopwatch in HH:MM:SS.msec format
+        """
+        return '%02d:%02d:%02d.%03d' % self.value_hms
+
+    def is_elapsed_ms(self, duration_ms):
+        """
+        Returns True if this timer has measured at least ``duration_ms``
+        milliseconds.
+        Otherwise, returns False. If ``duration_ms`` is None, returns False.
+        """
+
+        return duration_ms is not None and self.value_ms >= duration_ms
+
+    def is_elapsed_secs(self, duration_secs):
+        """
+        Returns True if this timer has measured at least ``duration_secs`` seconds.
+        Otherwise, returns False. If ``duration_secs`` is None, returns False.
+        """
+
+        return duration_secs is not None and self.value_secs >= duration_secs
+

--- a/ev3dev2/stopwatch.py
+++ b/ev3dev2/stopwatch.py
@@ -28,7 +28,6 @@ class StopWatch(object):
             A string description to print when stringifying.
         """
         self.desc = desc
-        self._value = 0
         self._start_time = None
         self._stopped_total_time = None
 

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -31,7 +31,7 @@ from ev3dev2.unit import (
 )
 
 import ev3dev2.stopwatch
-from ev3dev2.stopwatch import StopWatch
+from ev3dev2.stopwatch import StopWatch, StopWatchAlreadyStartedException
 
 ev3dev2.Device.DEVICE_ROOT_PATH = os.path.join(FAKE_SYS, 'arena')
 
@@ -427,8 +427,15 @@ class TestAPI(unittest.TestCase):
         self.assertEqual(sw.is_elapsed_ms(3000), True)
         self.assertEqual(sw.is_elapsed_secs(3), True)
 
-        # test start's reset behavior
-        sw.start()
+        try:
+            # StopWatch can't be started if already running
+            sw.start()
+            self.fail()
+        except StopWatchAlreadyStartedException:
+            pass
+
+        # test reset behavior
+        sw.restart()
         self.assertEqual(sw.is_started, True)
         self.assertEqual(sw.value_ms, 0)
         self.assertEqual(sw.value_secs, 0)
@@ -440,29 +447,6 @@ class TestAPI(unittest.TestCase):
         self.assertEqual(sw.is_elapsed_secs(3), False)
 
         set_mock_ticks_ms(1000 * 60 * 75.5 + 3000)
-        self.assertEqual(sw.is_started, True)
-        self.assertEqual(sw.value_ms, 3000)
-        self.assertEqual(sw.value_secs, 3)
-        self.assertEqual(sw.value_hms, (0,0,3,0))
-        self.assertEqual(sw.hms_str, "00:00:03.000")
-        self.assertEqual(sw.is_elapsed_ms(None), False)
-        self.assertEqual(sw.is_elapsed_secs(None), False)
-        self.assertEqual(sw.is_elapsed_ms(3000), True)
-        self.assertEqual(sw.is_elapsed_secs(3), True)
-
-        # test reset
-        sw.reset()
-        self.assertEqual(sw.is_started, True)
-        self.assertEqual(sw.value_ms, 0)
-        self.assertEqual(sw.value_secs, 0)
-        self.assertEqual(sw.value_hms, (0,0,0,0))
-        self.assertEqual(sw.hms_str, "00:00:00.000")
-        self.assertEqual(sw.is_elapsed_ms(None), False)
-        self.assertEqual(sw.is_elapsed_secs(None), False)
-        self.assertEqual(sw.is_elapsed_ms(3000), False)
-        self.assertEqual(sw.is_elapsed_secs(3), False)
-
-        set_mock_ticks_ms(1000 * 60 * 75.5 + 6000)
         self.assertEqual(sw.is_started, True)
         self.assertEqual(sw.value_ms, 3000)
         self.assertEqual(sw.value_secs, 3)
@@ -485,6 +469,29 @@ class TestAPI(unittest.TestCase):
         self.assertEqual(sw.is_elapsed_secs(None), False)
         self.assertEqual(sw.is_elapsed_ms(3000), True)
         self.assertEqual(sw.is_elapsed_secs(3), True)
+
+        # test reset
+        sw.reset()
+        self.assertEqual(sw.is_started, False)
+        self.assertEqual(sw.value_ms, 0)
+        self.assertEqual(sw.value_secs, 0)
+        self.assertEqual(sw.value_hms, (0,0,0,0))
+        self.assertEqual(sw.hms_str, "00:00:00.000")
+        self.assertEqual(sw.is_elapsed_ms(None), False)
+        self.assertEqual(sw.is_elapsed_secs(None), False)
+        self.assertEqual(sw.is_elapsed_ms(3000), False)
+        self.assertEqual(sw.is_elapsed_secs(3), False)
+
+        set_mock_ticks_ms(1000 * 60 * 75.5 + 6000)
+        self.assertEqual(sw.is_started, False)
+        self.assertEqual(sw.value_ms, 0)
+        self.assertEqual(sw.value_secs, 0)
+        self.assertEqual(sw.value_hms, (0,0,0,0))
+        self.assertEqual(sw.hms_str, "00:00:00.000")
+        self.assertEqual(sw.is_elapsed_ms(None), False)
+        self.assertEqual(sw.is_elapsed_secs(None), False)
+        self.assertEqual(sw.is_elapsed_ms(3000), False)
+        self.assertEqual(sw.is_elapsed_secs(3), False)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -30,6 +30,9 @@ from ev3dev2.unit import (
     DistanceStuds
 )
 
+import ev3dev2.stopwatch
+from ev3dev2.stopwatch import StopWatch
+
 ev3dev2.Device.DEVICE_ROOT_PATH = os.path.join(FAKE_SYS, 'arena')
 
 _internal_set_attribute = ev3dev2.Device._set_attribute
@@ -55,6 +58,16 @@ def dummy_wait(self, cond, timeout=None):
 
 Motor.wait = dummy_wait
 
+# for StopWatch
+mock_ticks_ms = 0
+def _mock_get_ticks_ms():
+    return mock_ticks_ms
+ev3dev2.stopwatch.get_ticks_ms = _mock_get_ticks_ms
+
+def set_mock_ticks_ms(value):
+    global mock_ticks_ms
+    mock_ticks_ms = value
+
 class TestAPI(unittest.TestCase):
 
     def setUp(self):
@@ -63,6 +76,9 @@ class TestAPI(unittest.TestCase):
             print("\n\n{}\n{}".format(self._testMethodName, "=" * len(self._testMethodName,)))
         except AttributeError:
             pass
+
+        # ensure tests don't depend on order based on StopWatch tick state
+        set_mock_ticks_ms(0)
 
     def test_device(self):
         clean_arena()
@@ -359,6 +375,116 @@ class TestAPI(unittest.TestCase):
 
         self.assertEqual(DistanceStuds(42).mm, 336)
 
+    def test_stopwatch(self):
+        sw = StopWatch()
+        self.assertEqual(str(sw), "StopWatch: 00:00:00.000")
+        
+        sw = StopWatch(desc="test sw")
+        self.assertEqual(str(sw), "test sw: 00:00:00.000")
+        self.assertEqual(sw.is_started, False)
+
+        sw.start()
+        self.assertEqual(sw.is_started, True)
+        self.assertEqual(sw.value_ms, 0)
+        self.assertEqual(sw.value_secs, 0)
+        self.assertEqual(sw.value_hms, (0,0,0,0))
+        self.assertEqual(sw.hms_str, "00:00:00.000")
+        self.assertEqual(sw.is_elapsed_ms(None), False)
+        self.assertEqual(sw.is_elapsed_secs(None), False)
+        self.assertEqual(sw.is_elapsed_ms(3000), False)
+        self.assertEqual(sw.is_elapsed_secs(3), False)
+
+        set_mock_ticks_ms(1500)
+        self.assertEqual(sw.is_started, True)
+        self.assertEqual(sw.value_ms, 1500)
+        self.assertEqual(sw.value_secs, 1.5)
+        self.assertEqual(sw.value_hms, (0,0,1,500))
+        self.assertEqual(sw.hms_str, "00:00:01.500")
+        self.assertEqual(sw.is_elapsed_ms(None), False)
+        self.assertEqual(sw.is_elapsed_secs(None), False)
+        self.assertEqual(sw.is_elapsed_ms(3000), False)
+        self.assertEqual(sw.is_elapsed_secs(3), False)
+
+        set_mock_ticks_ms(3000)
+        self.assertEqual(sw.is_started, True)
+        self.assertEqual(sw.value_ms, 3000)
+        self.assertEqual(sw.value_secs, 3)
+        self.assertEqual(sw.value_hms, (0,0,3,0))
+        self.assertEqual(sw.hms_str, "00:00:03.000")
+        self.assertEqual(sw.is_elapsed_ms(None), False)
+        self.assertEqual(sw.is_elapsed_secs(None), False)
+        self.assertEqual(sw.is_elapsed_ms(3000), True)
+        self.assertEqual(sw.is_elapsed_secs(3), True)
+
+        set_mock_ticks_ms(1000 * 60 * 75.5) #75.5 minutes
+        self.assertEqual(sw.is_started, True)
+        self.assertEqual(sw.value_ms, 1000 * 60 * 75.5)
+        self.assertEqual(sw.value_secs, 60 * 75.5)
+        self.assertEqual(sw.value_hms, (1,15,30,0))
+        self.assertEqual(sw.hms_str, "01:15:30.000")
+        self.assertEqual(sw.is_elapsed_ms(None), False)
+        self.assertEqual(sw.is_elapsed_secs(None), False)
+        self.assertEqual(sw.is_elapsed_ms(3000), True)
+        self.assertEqual(sw.is_elapsed_secs(3), True)
+
+        # test start's reset behavior
+        sw.start()
+        self.assertEqual(sw.is_started, True)
+        self.assertEqual(sw.value_ms, 0)
+        self.assertEqual(sw.value_secs, 0)
+        self.assertEqual(sw.value_hms, (0,0,0,0))
+        self.assertEqual(sw.hms_str, "00:00:00.000")
+        self.assertEqual(sw.is_elapsed_ms(None), False)
+        self.assertEqual(sw.is_elapsed_secs(None), False)
+        self.assertEqual(sw.is_elapsed_ms(3000), False)
+        self.assertEqual(sw.is_elapsed_secs(3), False)
+
+        set_mock_ticks_ms(1000 * 60 * 75.5 + 3000)
+        self.assertEqual(sw.is_started, True)
+        self.assertEqual(sw.value_ms, 3000)
+        self.assertEqual(sw.value_secs, 3)
+        self.assertEqual(sw.value_hms, (0,0,3,0))
+        self.assertEqual(sw.hms_str, "00:00:03.000")
+        self.assertEqual(sw.is_elapsed_ms(None), False)
+        self.assertEqual(sw.is_elapsed_secs(None), False)
+        self.assertEqual(sw.is_elapsed_ms(3000), True)
+        self.assertEqual(sw.is_elapsed_secs(3), True)
+
+        # test reset
+        sw.reset()
+        self.assertEqual(sw.is_started, True)
+        self.assertEqual(sw.value_ms, 0)
+        self.assertEqual(sw.value_secs, 0)
+        self.assertEqual(sw.value_hms, (0,0,0,0))
+        self.assertEqual(sw.hms_str, "00:00:00.000")
+        self.assertEqual(sw.is_elapsed_ms(None), False)
+        self.assertEqual(sw.is_elapsed_secs(None), False)
+        self.assertEqual(sw.is_elapsed_ms(3000), False)
+        self.assertEqual(sw.is_elapsed_secs(3), False)
+
+        set_mock_ticks_ms(1000 * 60 * 75.5 + 6000)
+        self.assertEqual(sw.is_started, True)
+        self.assertEqual(sw.value_ms, 3000)
+        self.assertEqual(sw.value_secs, 3)
+        self.assertEqual(sw.value_hms, (0,0,3,0))
+        self.assertEqual(sw.hms_str, "00:00:03.000")
+        self.assertEqual(sw.is_elapsed_ms(None), False)
+        self.assertEqual(sw.is_elapsed_secs(None), False)
+        self.assertEqual(sw.is_elapsed_ms(3000), True)
+        self.assertEqual(sw.is_elapsed_secs(3), True)
+
+        # test stop
+        sw.stop()
+        set_mock_ticks_ms(1000 * 60 * 75.5 + 10000)
+        self.assertEqual(sw.is_started, False)
+        self.assertEqual(sw.value_ms, 3000)
+        self.assertEqual(sw.value_secs, 3)
+        self.assertEqual(sw.value_hms, (0,0,3,0))
+        self.assertEqual(sw.hms_str, "00:00:03.000")
+        self.assertEqual(sw.is_elapsed_ms(None), False)
+        self.assertEqual(sw.is_elapsed_secs(None), False)
+        self.assertEqual(sw.is_elapsed_ms(3000), True)
+        self.assertEqual(sw.is_elapsed_secs(3), True)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Also did general clean-up and added documentation. Removed intermediate "value" so that accessors don't modify state.

There is one breaking change (I believe everything else is backwards-compatible): "value_hms" now returns the unstringified tuple, and a new "hms_str" returns the string version. Also changed the `__str__` format to include the hms string but I don't view that as a breaking change.

Useful for #665.