### PR TITLE
Fix gyro sensor reset

### DIFF
--- a/ev3dev2/sensor/lego.py
+++ b/ev3dev2/sensor/lego.py
@@ -631,7 +631,7 @@ class GyroSensor(Sensor):
               PiStorms, or with any sensor multiplexors.
         """
         # 17 comes from inspecting the .vix file of the Gyro sensor block in EV3-G
-        self._direct = self.set_attr_raw(self._direct, 'direct', bytes(17,))
+        self._direct = self.set_attr_raw(self._direct, 'direct', b'\x11')
 
     def wait_until_angle_changed_by(self, delta, direction_sensitive=False):
         """


### PR DESCRIPTION
Gyro sensor reset was failing because we were writing 17 bytes of 0
to the gyro sensor instead of the byte 17.

Also change it to a bytes literal for max efficiency.