### PR TITLE
MoveDifferential: use gyro support for better accuracy (reverted this commit)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,9 @@
 python-ev3dev2 (2.1.0) UNRELEASED; urgency=medium
 
   [Daniel Walton]
+  * RPyC update docs and make it easier to use
   * MoveDifferential use gyro for better accuracy. Make MoveTank and
     MoveDifferential "turn" APIs more consistent.
-  * RPyC update docs and make it easier to use
 
   [Matěj Volf]
   * LED animation fix duration None

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,8 @@
 python-ev3dev2 (2.1.0) UNRELEASED; urgency=medium
 
+  [Daniel Walton]
+  * MoveDifferential._turn() use gyro for better accuracy
+
   [Matěj Volf]
   * LED animation fix duration None
   * Add rest notes to sound.Sound.play_song()

--- a/debian/changelog
+++ b/debian/changelog
@@ -4,7 +4,7 @@ python-ev3dev2 (2.1.0) UNRELEASED; urgency=medium
   * Add "value_secs" and "is_elapsed_*" methods to StopWatch
   * Rename "value_hms" to "hms_str". New "value_hms" returns original tuple.
   * Fix bug in Button.process() on Micropython
-  
+
   [Nithin Shenoy]
   * Add Gyro-based driving support to MoveTank
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,8 @@
 python-ev3dev2 (2.1.0) UNRELEASED; urgency=medium
 
   [Daniel Walton]
-  * MoveDifferential._turn() use gyro for better accuracy
+  * MoveDifferential use gyro for better accuracy. Make MoveTank and
+    MoveDifferential "turn" APIs more consistent.
 
   [Matěj Volf]
   * LED animation fix duration None

--- a/ev3dev2/__init__.py
+++ b/ev3dev2/__init__.py
@@ -142,6 +142,12 @@ def library_load_warning_message(library_name, dependent_class):
 class DeviceNotFound(Exception):
     pass
 
+class DeviceNotDefined(Exception):
+    pass
+
+class ThreadNotRunning(Exception):
+    pass
+
 # -----------------------------------------------------------------------------
 # Define the base class from which all other ev3dev classes are defined.
 

--- a/ev3dev2/__init__.py
+++ b/ev3dev2/__init__.py
@@ -241,7 +241,7 @@ class Device(object):
         """Device attribute getter"""
         try:
             if attribute is None:
-                attribute = self._attribute_file_open( name )
+                attribute = self._attribute_file_open(name)
             else:
                 attribute.seek(0)
             return attribute, attribute.read().strip().decode()
@@ -252,7 +252,7 @@ class Device(object):
         """Device attribute setter"""
         try:
             if attribute is None:
-                attribute = self._attribute_file_open( name )
+                attribute = self._attribute_file_open(name)
             else:
                 attribute.seek(0)
 

--- a/ev3dev2/__init__.py
+++ b/ev3dev2/__init__.py
@@ -217,7 +217,7 @@ class Device(object):
             return "%s(%s)" % (self.__class__.__name__, self.kwargs.get('address'))
         else:
             return self.__class__.__name__
-    
+
     def __repr__(self):
         return self.__str__()
 

--- a/ev3dev2/__init__.py
+++ b/ev3dev2/__init__.py
@@ -50,7 +50,6 @@ import fnmatch
 import re
 import stat
 import errno
-import _thread
 from os.path import abspath
 
 def get_current_platform():
@@ -153,7 +152,6 @@ class Device(object):
         '_path',
         '_device_index',
         '_attr_cache',
-        '_file_lock',
         'kwargs',
     ]
 
@@ -189,7 +187,6 @@ class Device(object):
         classpath = abspath(Device.DEVICE_ROOT_PATH + '/' + class_name)
         self.kwargs = kwargs
         self._attr_cache = {}
-        self._file_lock = _thread.allocate_lock()
 
         def get_index(file):
             match = Device._DEVICE_INDEX.match(file)
@@ -242,25 +239,20 @@ class Device(object):
 
     def _get_attribute(self, attribute, name):
         """Device attribute getter"""
-        self._file_lock.acquire()
         try:
             if attribute is None:
-                attribute = self._attribute_file_open(name)
+                attribute = self._attribute_file_open( name )
             else:
                 attribute.seek(0)
-            result = attribute.read().strip().decode()
-            self._file_lock.release()
-            return attribute, result
+            return attribute, attribute.read().strip().decode()
         except Exception as ex:
-            self._file_lock.release()
             self._raise_friendly_access_error(ex, name, None)
 
     def _set_attribute(self, attribute, name, value):
         """Device attribute setter"""
-        self._file_lock.acquire()
         try:
             if attribute is None:
-                attribute = self._attribute_file_open(name)
+                attribute = self._attribute_file_open( name )
             else:
                 attribute.seek(0)
 
@@ -268,12 +260,9 @@ class Device(object):
                 value = value.encode()
             attribute.write(value)
             attribute.flush()
-            self._file_lock.release()
-            return attribute
-
         except Exception as ex:
-            self._file_lock.release()
             self._raise_friendly_access_error(ex, name, value)
+        return attribute
 
     def _raise_friendly_access_error(self, driver_error, attribute, value):
         if not isinstance(driver_error, OSError):

--- a/ev3dev2/motor.py
+++ b/ev3dev2/motor.py
@@ -2249,8 +2249,7 @@ class MoveTank(MotorSet):
         """
 
         # MoveTank does not have information on wheel size and distance (that is
-        # MoveDifferential) so we must have a GyroSensor to control how far we
-        # have rotated.
+        # MoveDifferential) so we must use a GyroSensor to control how far we rotate.
         assert self._gyro, "GyroSensor must be defined"
 
         if not target_angle:

--- a/ev3dev2/motor.py
+++ b/ev3dev2/motor.py
@@ -2706,9 +2706,9 @@ class MoveDifferential(MoveTank):
                 if sleep_time:
                     time.sleep(sleep_time)
 
-            log.info("_odometry_monitor stopped")
             self.odometry_thread_run = False
             self.odometry_thread_running = False
+            log.info("_odometry_monitor stopped")
 
         _thread.start_new_thread(_odometry_monitor, ())
         self.odometry_thread_running = True

--- a/ev3dev2/motor.py
+++ b/ev3dev2/motor.py
@@ -2292,13 +2292,13 @@ class MoveTank(MotorSet):
 
     def turn_right(self, speed, degrees, brake=True, error_margin=2, sleep_time=0.01):
         """
-        Rotate clockwise `degrees` in place
+        Rotate clockwise ``degrees`` in place
         """
         self.turn_degrees(speed, abs(degrees), brake, error_margin, sleep_time)
 
     def turn_left(self, speed, degrees, brake=True, error_margin=2, sleep_time=0.01):
         """
-        Rotate counter-clockwise `degrees` in place
+        Rotate counter-clockwise ``degrees`` in place
         """
         self.turn_degrees(speed, abs(degrees) * -1, brake, error_margin, sleep_time)
 
@@ -2642,19 +2642,19 @@ class MoveDifferential(MoveTank):
 
     def turn_right(self, speed, degrees, brake=True, block=True, error_margin=2, use_gyro=False):
         """
-        Rotate clockwise `degrees` in place
+        Rotate clockwise ``degrees`` in place
         """
         self.turn_degrees(speed, abs(degrees), brake, block, error_margin, use_gyro)
 
     def turn_left(self, speed, degrees, brake=True, block=True, error_margin=2, use_gyro=False):
         """
-        Rotate counter-clockwise `degrees` in place
+        Rotate counter-clockwise ``degrees`` in place
         """
         self.turn_degrees(speed, abs(degrees) * -1, brake, block, error_margin, use_gyro)
 
     def turn_to_angle(self, speed, angle_target_degrees, brake=True, block=True, error_margin=2, use_gyro=False):
         """
-        Rotate in place to `angle_target_degrees` at `speed`
+        Rotate in place to ``angle_target_degrees`` at ``speed``
         """
         if not self.odometry_thread_run:
             raise ThreadNotRunning("odometry_start() must be called to track robot coordinates")
@@ -2804,7 +2804,7 @@ class MoveJoystick(MoveTank):
 
     def on(self, x, y, radius=100.0):
         """
-        Convert x,y joystick coordinates to left/right motor speed percentages
+        Convert ``x``,``y`` joystick coordinates to left/right motor speed percentages
         and move the motors.
 
         This will use a classic "arcade drive" algorithm: a full-forward joystick
@@ -2813,11 +2813,11 @@ class MoveJoystick(MoveTank):
         Positions in the middle will control how fast the vehicle moves and how
         sharply it turns.
 
-        "x", "y":
+        ``x``, ``y``:
             The X and Y coordinates of the joystick's position, with
             (0,0) representing the center position. X is horizontal and Y is vertical.
 
-        radius (default 100):
+        ``radius`` (default 100):
             The radius of the joystick, controlling the range of the input (x, y) values.
             e.g. if "x" and "y" can be between -1 and 1, radius should be set to "1".
         """

--- a/ev3dev2/sensor/__init__.py
+++ b/ev3dev2/sensor/__init__.py
@@ -274,7 +274,7 @@ class Sensor(Device):
         if fmt is None: return raw
 
         return unpack(fmt, raw)
-    
+
     def _ensure_mode(self, mode):
         if self.mode != mode:
             self.mode = mode

--- a/ev3dev2/sensor/lego.py
+++ b/ev3dev2/sensor/lego.py
@@ -635,15 +635,8 @@ class GyroSensor(Sensor):
         time.sleep(2)
         self._ensure_mode(current_mode)
 
-    def reset(self, block=False):
-        """
-        Resets the angle to 0. If `block` is True the function will wait
-        until the angle is 0 before returning.
-
-        Caveats:
-            - This function only resets the angle to 0, it does not fix drift.
-            - This function only works on EV3, it does not work on BrickPi,
-              PiStorms, or with any sensor multiplexors.
+    def reset(self):
+        """Resets the angle to 0.
         """
         # 17 comes from inspecting the .vix file of the Gyro sensor block in EV3-G
         self._direct = self.set_attr_raw(self._direct, 'direct', b'\x11')

--- a/ev3dev2/sensor/lego.py
+++ b/ev3dev2/sensor/lego.py
@@ -637,6 +637,11 @@ class GyroSensor(Sensor):
 
     def reset(self):
         """Resets the angle to 0.
+
+        Caveats:
+            - This function only resets the angle to 0, it does not fix drift.
+            - This function only works on EV3, it does not work on BrickPi,
+              PiStorms, or with any sensor multiplexors.
         """
         # 17 comes from inspecting the .vix file of the Gyro sensor block in EV3-G
         self._direct = self.set_attr_raw(self._direct, 'direct', b'\x11')

--- a/ev3dev2/sensor/lego.py
+++ b/ev3dev2/sensor/lego.py
@@ -647,27 +647,6 @@ class GyroSensor(Sensor):
         """
         # 17 comes from inspecting the .vix file of the Gyro sensor block in EV3-G
         self._direct = self.set_attr_raw(self._direct, 'direct', b'\x11')
-
-        # If block is True wait until the angle reads 0
-        if block:
-            MAX_ATTEMPTS = 20
-            SLEEP_AMOUNT = 0.1  # 100ms
-
-            for x in range(MAX_ATTEMPTS):
-                try:
-                    if self.angle:
-                        time.sleep(SLEEP_AMOUNT)
-                    else:
-                        break
-
-                # When we reset the gyro and then attempt to read the angle the
-                # read may fail if the gyro is in the middle of reseting.
-                except OSError:
-                    time.sleep(SLEEP_AMOUNT)
-
-            else:
-                raise Exception("%s did not reset, angle %s" % (self, self.angle))
-
         self._init_angle = self.angle
 
     def wait_until_angle_changed_by(self, delta, direction_sensitive=False):

--- a/ev3dev2/stopwatch.py
+++ b/ev3dev2/stopwatch.py
@@ -70,14 +70,14 @@ class StopWatch(object):
         """
         self._start_time = None
         self._stopped_total_time = None
-    
+
     def restart(self):
         """
         Resets and then starts the timer.
         """
         self.reset()
         self.start()
-    
+
     @property
     def is_started(self):
         """

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -378,7 +378,7 @@ class TestAPI(unittest.TestCase):
     def test_stopwatch(self):
         sw = StopWatch()
         self.assertEqual(str(sw), "StopWatch: 00:00:00.000")
-        
+
         sw = StopWatch(desc="test sw")
         self.assertEqual(str(sw), "test sw: 00:00:00.000")
         self.assertEqual(sw.is_started, False)

--- a/tests/motor/ev3dev_port_logger.py
+++ b/tests/motor/ev3dev_port_logger.py
@@ -49,7 +49,7 @@ def execute_actions(actions):
         for b in c:
             for k,v in b.items():
                 setattr( device[p], k, v )
- 
+
 device = {}
 logs = {}
 

--- a/tests/motor/motor_run_direct_unittest.py
+++ b/tests/motor/motor_run_direct_unittest.py
@@ -30,7 +30,7 @@ class TestMotorRunDirect(ptc.ParameterizedTestCase):
         self._param['motor'].command = 'run-direct'
 
         for i in duty_cycles:
-            self._param['motor'].duty_cycle_sp = i 
+            self._param['motor'].duty_cycle_sp = i
             time.sleep(0.5)
 
         self._param['motor'].command = 'stop'

--- a/tests/motor/motor_unittest.py
+++ b/tests/motor/motor_unittest.py
@@ -298,7 +298,7 @@ class TestTachoMotorRampDownSpValue(ptc.ParameterizedTestCase):
         self.assertEqual(self._param['motor'].ramp_down_sp, 100)
         self._param['motor'].command = 'reset'
         self.assertEqual(self._param['motor'].ramp_down_sp, 0)
-        
+
 class TestTachoMotorRampUpSpValue(ptc.ParameterizedTestCase):
 
     def test_ramp_up_negative_value(self):
@@ -326,7 +326,7 @@ class TestTachoMotorRampUpSpValue(ptc.ParameterizedTestCase):
         self.assertEqual(self._param['motor'].ramp_up_sp, 100)
         self._param['motor'].command = 'reset'
         self.assertEqual(self._param['motor'].ramp_up_sp, 0)
-        
+
 class TestTachoMotorSpeedValue(ptc.ParameterizedTestCase):
 
     def test_speed_value_is_read_only(self):
@@ -337,7 +337,7 @@ class TestTachoMotorSpeedValue(ptc.ParameterizedTestCase):
     def test_speed_value_after_reset(self):
         self._param['motor'].command = 'reset'
         self.assertEqual(self._param['motor'].speed, 0)
-        
+
 class TestTachoMotorSpeedSpValue(ptc.ParameterizedTestCase):
 
    def test_speed_sp_large_negative(self):
@@ -373,7 +373,7 @@ class TestTachoMotorSpeedSpValue(ptc.ParameterizedTestCase):
         self.assertEqual(self._param['motor'].speed_sp, 100)
         self._param['motor'].command = 'reset'
         self.assertEqual(self._param['motor'].speed_sp, 0)
-        
+
 class TestTachoMotorSpeedPValue(ptc.ParameterizedTestCase):
 
     def test_speed_i_negative(self):

--- a/utils/move_differential.py
+++ b/utils/move_differential.py
@@ -4,12 +4,10 @@
 Used to experiment with the MoveDifferential class
 """
 
-from ev3dev2.sensor.lego import GyroSensor
 from ev3dev2.motor import OUTPUT_A, OUTPUT_B, MoveDifferential, SpeedRPM
 from ev3dev2.wheel import EV3Tire
 from ev3dev2.unit import DistanceFeet
 from math import pi
-from time import sleep
 import logging
 import sys
 
@@ -34,7 +32,6 @@ ONE_FOOT_CICLE_CIRCUMFERENCE_MM = 2 * pi * ONE_FOOT_CICLE_RADIUS_MM
 # wheel seperation.
 # https://sites.google.com/site/ev3basic/ev3-basic-programming/going-further/writerbot-v1/drawing-arcs
 mdiff = MoveDifferential(OUTPUT_A, OUTPUT_B, EV3Tire, 16.3 * STUD_MM)
-mdiff.gyro = GyroSensor()
 
 # This goes crazy on brickpi3, does it do the same on ev3?
 #mdiff.on_for_distance(SpeedRPM(-40), 720, brake=False)
@@ -42,20 +39,17 @@ mdiff.gyro = GyroSensor()
 
 # Test arc left/right turns
 #mdiff.on_arc_right(SpeedRPM(80), ONE_FOOT_CICLE_RADIUS_MM, ONE_FOOT_CICLE_CIRCUMFERENCE_MM / 4)
-#mdiff.on_arc_left(SpeedRPM(80), ONE_FOOT_CICLE_RADIUS_MM, ONE_FOOT_CICLE_CIRCUMFERENCE_MM)
+mdiff.on_arc_left(SpeedRPM(80), ONE_FOOT_CICLE_RADIUS_MM, ONE_FOOT_CICLE_CIRCUMFERENCE_MM)
 
 # Test turning in place
 #mdiff.turn_right(SpeedRPM(40), 180)
 #mdiff.turn_left(SpeedRPM(40), 180)
 
 # Test odometry
-mdiff.odometry_start()
-mdiff.turn_to_angle(SpeedRPM(40), 0)
-print("\n\n\n\n")
-mdiff.turn_to_angle(SpeedRPM(40), 90)
-print("\n\n\n\n")
-sys.exit(0)
+#mdiff.odometry_start()
+#mdiff.odometry_coordinates_log()
 
+#mdiff.turn_to_angle(SpeedRPM(40), 0)
 #mdiff.on_for_distance(SpeedRPM(40), DistanceFeet(2).mm)
 #mdiff.turn_right(SpeedRPM(40), 180)
 #mdiff.turn_left(SpeedRPM(30), 90)
@@ -87,16 +81,6 @@ sys.exit(0)
 #mdiff.on_to_coordinates(SpeedRPM(40), 0, 0)
 #mdiff.turn_to_angle(SpeedRPM(40), 90)
 
-prev_gyro_angle = None
-log.info("FOO")
 
-while True:
-    gyro_angle = mdiff.gyro.angle
-
-    log.info(gyro_angle)
-    if prev_gyro_angle is not None and gyro_angle == prev_gyro_angle:
-        break
-    sleep(1)
-    prev_gyro_angle = gyro_angle
-
-mdiff.odometry_stop()
+#mdiff.odometry_coordinates_log()
+#mdiff.odometry_stop()

--- a/utils/move_differential.py
+++ b/utils/move_differential.py
@@ -51,6 +51,11 @@ mdiff.gyro = GyroSensor()
 # Test odometry
 mdiff.odometry_start()
 mdiff.turn_to_angle(SpeedRPM(40), 0)
+print("\n\n\n\n")
+mdiff.turn_to_angle(SpeedRPM(40), 90)
+print("\n\n\n\n")
+sys.exit(0)
+
 #mdiff.on_for_distance(SpeedRPM(40), DistanceFeet(2).mm)
 #mdiff.turn_right(SpeedRPM(40), 180)
 #mdiff.turn_left(SpeedRPM(30), 90)

--- a/utils/move_differential.py
+++ b/utils/move_differential.py
@@ -4,10 +4,12 @@
 Used to experiment with the MoveDifferential class
 """
 
+from ev3dev2.sensor.lego import GyroSensor
 from ev3dev2.motor import OUTPUT_A, OUTPUT_B, MoveDifferential, SpeedRPM
 from ev3dev2.wheel import EV3Tire
 from ev3dev2.unit import DistanceFeet
 from math import pi
+from time import sleep
 import logging
 import sys
 
@@ -32,6 +34,7 @@ ONE_FOOT_CICLE_CIRCUMFERENCE_MM = 2 * pi * ONE_FOOT_CICLE_RADIUS_MM
 # wheel seperation.
 # https://sites.google.com/site/ev3basic/ev3-basic-programming/going-further/writerbot-v1/drawing-arcs
 mdiff = MoveDifferential(OUTPUT_A, OUTPUT_B, EV3Tire, 16.3 * STUD_MM)
+mdiff.gyro = GyroSensor()
 
 # This goes crazy on brickpi3, does it do the same on ev3?
 #mdiff.on_for_distance(SpeedRPM(-40), 720, brake=False)
@@ -39,17 +42,15 @@ mdiff = MoveDifferential(OUTPUT_A, OUTPUT_B, EV3Tire, 16.3 * STUD_MM)
 
 # Test arc left/right turns
 #mdiff.on_arc_right(SpeedRPM(80), ONE_FOOT_CICLE_RADIUS_MM, ONE_FOOT_CICLE_CIRCUMFERENCE_MM / 4)
-mdiff.on_arc_left(SpeedRPM(80), ONE_FOOT_CICLE_RADIUS_MM, ONE_FOOT_CICLE_CIRCUMFERENCE_MM)
+#mdiff.on_arc_left(SpeedRPM(80), ONE_FOOT_CICLE_RADIUS_MM, ONE_FOOT_CICLE_CIRCUMFERENCE_MM)
 
 # Test turning in place
 #mdiff.turn_right(SpeedRPM(40), 180)
 #mdiff.turn_left(SpeedRPM(40), 180)
 
 # Test odometry
-#mdiff.odometry_start()
-#mdiff.odometry_coordinates_log()
-
-#mdiff.turn_to_angle(SpeedRPM(40), 0)
+mdiff.odometry_start()
+mdiff.turn_to_angle(SpeedRPM(40), 0)
 #mdiff.on_for_distance(SpeedRPM(40), DistanceFeet(2).mm)
 #mdiff.turn_right(SpeedRPM(40), 180)
 #mdiff.turn_left(SpeedRPM(30), 90)
@@ -81,6 +82,16 @@ mdiff.on_arc_left(SpeedRPM(80), ONE_FOOT_CICLE_RADIUS_MM, ONE_FOOT_CICLE_CIRCUMF
 #mdiff.on_to_coordinates(SpeedRPM(40), 0, 0)
 #mdiff.turn_to_angle(SpeedRPM(40), 90)
 
+prev_gyro_angle = None
+log.info("FOO")
 
-#mdiff.odometry_coordinates_log()
-#mdiff.odometry_stop()
+while True:
+    gyro_angle = mdiff.gyro.angle
+
+    log.info(gyro_angle)
+    if prev_gyro_angle is not None and gyro_angle == prev_gyro_angle:
+        break
+    sleep(1)
+    prev_gyro_angle = gyro_angle
+
+mdiff.odometry_stop()


### PR DESCRIPTION
- Resolves #620 
- unify (as much as possible) the *turn* API for MoveTank and MoveDifferential.  MoveTank recently got gryo support so we needed to cleanup the API between it and MoveDifferential.
- removed all trailing whitespaces in various files
