### PR TITLE
Use new .readthedocs.yml rather than manual pip invocation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,12 @@
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+formats: all
+
+python:
+  version: 3.7
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,11 +23,6 @@ from recommonmark.transform import AutoStructify
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from git_version import git_version  # noqa: E402
 
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-
-if on_rtd:
-    subprocess.check_call([sys.executable, '-m', 'pip', 'install', 'sphinx_bootstrap_theme', 'recommonmark', 'evdev'])
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,4 @@
 docutils==0.14
+sphinx_bootstrap_theme
+recommonmark
+evdev


### PR DESCRIPTION
It seems that RTD is no longer seeing the installed modules with the way we used to do it.