### PR TITLE
Fix Lab color space conversion

### DIFF
--- a/ev3dev2/sensor/lego.py
+++ b/ev3dev2/sensor/lego.py
@@ -277,6 +277,7 @@ class ColorSensor(Sensor):
         XYZ = [0, 0, 0]
 
         for (num, value) in enumerate(self.rgb):
+            value /= 255 # scale rgb input to [0,1]
             if value > 0.04045:
                 value = pow(((value + 0.055) / 1.055), 2.4)
             else:


### PR DESCRIPTION
In the current Lab conversion the RGB colors are not scaled to [0,1], resulting in the Lab color space being out of scale.